### PR TITLE
Feature/#13 swagger 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,17 +26,25 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	//spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	testImplementation 'org.springframework.security:spring-security-test'
 
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// swagger
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
 
 	//oauthTest
 	//implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
+++ b/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
@@ -4,51 +4,55 @@ import MusicPlatform.domain.track.repository.dto.request.TrackRequestDto;
 import MusicPlatform.domain.track.repository.dto.request.TrackUpdateRequestDto;
 import MusicPlatform.domain.track.repository.dto.response.TrackResponseDto;
 import MusicPlatform.domain.track.service.TrackService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
-
 import jakarta.validation.Valid;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping
 @RequiredArgsConstructor
+@Tag(name = "트랙 (Track)")
 public class TrackController {
 
     private final TrackService trackService;
 
-    @PostMapping("album/{uuid}/track")
-    public ResponseEntity<Void> uploadTrack(@RequestPart @Valid TrackRequestDto requestDto,
-                                            @RequestPart(required = false) final MultipartFile file,
+    @Operation(summary = "트랙 업로드")
+    @PostMapping(value = "album/{uuid}/track")
+    public ResponseEntity<Void> uploadTrack(@ModelAttribute @Valid TrackRequestDto requestDto,
                                             @PathVariable String uuid) {
-        trackService.save(requestDto, file, uuid);
+        trackService.save(requestDto, uuid);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Operation(summary = "트랙 조회")
     @GetMapping("/track/{uuid}")
     public ResponseEntity<TrackResponseDto> getByUuid(@PathVariable String uuid) {
         TrackResponseDto responseDto = trackService.getTrack(uuid);
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(summary = "특정 아티스트의 트랙 목록 조회")
     @GetMapping("/artist/{uuid}/track")
     public ResponseEntity<List<TrackResponseDto>> getAllByArtist(@PathVariable String uuid) {
         List<TrackResponseDto> responseDto = trackService.getAllByArtist(uuid);
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(summary = "트랙 수정")
     @PatchMapping("/track/{uuid}")
     public ResponseEntity<Void> updateByUuid(@RequestBody @Valid TrackUpdateRequestDto requestDto,
                                              @PathVariable String uuid) {
@@ -56,6 +60,7 @@ public class TrackController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "트랙 삭제")
     @DeleteMapping("/track/{uuid}")
     public ResponseEntity<Void> deleteByUuid(@PathVariable String uuid) {
         trackService.deleteByUuid(uuid);

--- a/src/main/java/MusicPlatform/domain/track/repository/dto/request/TrackRequestDto.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/dto/request/TrackRequestDto.java
@@ -2,12 +2,15 @@ package MusicPlatform.domain.track.repository.dto.request;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.multipart.MultipartFile;
 
 public record TrackRequestDto(
         @NotBlank
         String title,
 
         @Nullable
-        String lyric
+        String lyric,
+
+         MultipartFile TrackFile
 ) {
 }

--- a/src/main/java/MusicPlatform/domain/track/service/TrackService.java
+++ b/src/main/java/MusicPlatform/domain/track/service/TrackService.java
@@ -16,7 +16,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -34,7 +33,7 @@ public class TrackService {
                 new BusinessException(NOT_FOUND_TRACK));
     }
 
-    public void save(TrackRequestDto requestDto, MultipartFile file, String albumUuid) {
+    public void save(TrackRequestDto requestDto, String albumUuid) {
         Album album = albumService.getByUuid(albumUuid);
 
         // String songUrl = s3Service.uploadToS3(); //todo:  s3 파일 업로드 구현

--- a/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
@@ -21,7 +21,7 @@ public class Oauth2ClientConfig {
     @Bean
     SecurityFilterChain securityFilterChane(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(requests ->
-                requests.requestMatchers("/").permitAll()
+                requests.requestMatchers("/**", "/api-docs/**", "/swagger-ui/**").permitAll()
         );
 
         http.csrf(AbstractHttpConfigurer::disable);

--- a/src/main/java/MusicPlatform/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/MusicPlatform/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package MusicPlatform.global.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Untitled API Document")
+                .version("v0.1.0-alpha");
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+
+    @Bean
+    public GroupedOpenApi allApi() {
+        return GroupedOpenApi.builder()
+                .group("all")
+                .displayName("All API")
+                .pathsToMatch("/**")
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,17 @@ cors:
   allow:
     origins: http://localhost:3000
     methods: GET, POST, PUT, DELETE, PATCH, OPTION
+
+# swagger
+springdoc:
+  packages-to-scan: MusicPlatform
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /api-docs
+  cache:
+    disabled: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #13 
#3, #4 


## 📝 작업 내용

Swagger 연동을 진행했습니다.
- SwaggerConfig 작성
- SpringDoc 설정 작성
- Swagger 문서에 로그인 없이 접속 가능하도록 Spring Security 설정 수정

추가로 트랙 업로드 api의 파일 업로드시 사용한 @ReqeustPart가 Swagger와의 연동성이 떨어져서 (reqeust parameter가 swagger 상으로 굉장히 불명확하게 나타남) @AttributeModel로 변경하는 작업을 수행했습니다. 
