### PR TITLE
Feature/#15 jwt 토큰 변환 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,13 +30,18 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
+	
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	//oauthTest
 	//implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
@@ -25,19 +25,21 @@ public class ArtistService {
                 new BusinessException(NOT_FOUND_ARTIST));
     }
 
-    public void register(String registrationId, ProviderUser providerUser) {
-        if (artistRepository.findByEmail(providerUser.getEmail()) != null) { // 이미 가입한 회원 검증
-            return;
+    public Artist register(String registrationId, ProviderUser providerUser) {
+        Artist existArtist = artistRepository.findByEmail(providerUser.getEmail());
+        if (existArtist != null) { // 이미 가입한 회원 검증
+            return existArtist;
         }
 
         Artist artist = Artist.builder()
                 .email(providerUser.getEmail())
-                .name(providerUser.getUsername())
+                .name(providerUser.getName())
                 .provider(registrationId)
-                .artistImage("") //todo 기본 이미지 등록
+                .artistImage(providerUser.getPicture()) //todo 기본 이미지 등록
                 .build();
 
         artistRepository.save(artist);
         profileService.createProfile(artist);
+        return artist;
     }
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/adapter/AuthenticationAdapter.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/adapter/AuthenticationAdapter.java
@@ -1,0 +1,5 @@
+package MusicPlatform.domain.oauth2.adapter;
+
+public interface AuthenticationAdapter {
+    String getUuid();
+}

--- a/src/main/java/MusicPlatform/domain/oauth2/entity/GoogleUser.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/entity/GoogleUser.java
@@ -1,9 +1,12 @@
 package MusicPlatform.domain.oauth2.entity;
 
+import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
-public class GoogleUser extends OAuth2ProviderUser {
+public class GoogleUser extends OAuth2ProviderUser implements AuthenticationAdapter {
+
+    private String uuid;
 
     public GoogleUser(OAuth2User oAuth2User, ClientRegistration clientRegistration) {
         super(oAuth2User.getAttributes(), oAuth2User, clientRegistration);
@@ -15,7 +18,22 @@ public class GoogleUser extends OAuth2ProviderUser {
     }
 
     @Override
-    public String getUsername() {
-        return getAttributes().get("sub").toString();
+    public String getName() {
+        return getAttributes().get("name").toString();
+    }
+
+    @Override
+    public String getPicture() {
+        return getAttributes().get("picture").toString();
+    }
+
+    @Override
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public String getUuid() {
+        return this.uuid;
     }
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/entity/ProviderUser.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/entity/ProviderUser.java
@@ -1,15 +1,21 @@
 package MusicPlatform.domain.oauth2.entity;
 
+import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
 import java.util.List;
 import java.util.Map;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
-public interface ProviderUser {
+public interface ProviderUser extends OAuth2User {
     String getId();
-    String getUsername();
+    String getName();
     String getPassword();
     String getEmail();
     String getProvider();
+    String getPicture();
+
     List<? extends GrantedAuthority> getAuthorities();
     Map<String, Object> getAttributes();
+    void setUuid(String uuid);
+
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
@@ -1,0 +1,41 @@
+package MusicPlatform.domain.oauth2.service;
+
+import MusicPlatform.global.provider.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CookieService {
+    @Value("${cookie.max-age}")
+    private int maxAge;
+    @Value("${cookie.domain}")
+    private String domain;
+    private final JwtProvider jwtProvider;
+
+    public Cookie makeAccessTokenCookie(String token) {
+        return this.makeCookie("access_token", token, maxAge);
+    }
+
+    public Cookie deleteAccessTokenCookie() {
+        return this.makeCookie("access_token", null, 0);
+    }
+
+    private Cookie makeCookie(String key, String value, int maxAge) {
+        Cookie cookie = new Cookie(key, value);
+        //cookie.setSecure(true); // HTTPS에서만 쿠키가 전송되도록 설정
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setDomain(domain);
+        cookie.setMaxAge(maxAge);
+        return cookie;
+    }
+
+    public void authenticate(String uuid, HttpServletResponse response) {
+        String accessToken = jwtProvider.createToken(uuid);
+        response.addCookie(this.makeAccessTokenCookie(accessToken));
+    }
+}

--- a/src/main/java/MusicPlatform/domain/oauth2/service/OAuth2UserService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/OAuth2UserService.java
@@ -1,5 +1,6 @@
 package MusicPlatform.domain.oauth2.service;
 
+import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.oauth2.entity.GoogleUser;
 import MusicPlatform.domain.oauth2.entity.ProviderUser;
@@ -26,10 +27,10 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest); //사용자 정보 반환
         ProviderUser providerUser = providerUser(clientRegistration, oAuth2User);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        artistService.register(registrationId, providerUser);
-        log.info("회원가입 = " + providerUser.getUsername());
-
-        return oAuth2User;
+        Artist artist = artistService.register(registrationId, providerUser);
+        log.info("회원가입 = " + providerUser.getName());
+        providerUser.setUuid(artist.getUuid());
+        return providerUser;
     }
 
     private ProviderUser providerUser(ClientRegistration clientRegistration, OAuth2User oAuth2User) {

--- a/src/main/java/MusicPlatform/global/handler/LoginSuccessHandler.java
+++ b/src/main/java/MusicPlatform/global/handler/LoginSuccessHandler.java
@@ -1,5 +1,8 @@
 package MusicPlatform.global.handler;
 
+import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
+import MusicPlatform.domain.oauth2.service.CookieService;
+import MusicPlatform.global.provider.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
@@ -16,18 +19,25 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Transactional
 @RequiredArgsConstructor
 public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-
+    private final CookieService cookieService;
     private final String authServer = "http://localhost:3000";
+
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
 
+        AuthenticationAdapter authenticationAdapter = (AuthenticationAdapter) authentication.getPrincipal();
+
+        String uuid = authenticationAdapter.getUuid();
+
+        cookieService.authenticate(uuid, response);
+
         String url = UriComponentsBuilder.fromUriString(authServer)
                 .path("")
                 .build()
                 .toUriString();
-        log.info("로그인 성공 LoginSuccessHandler-redirectUrl = " + url);
+
         response.sendRedirect(url);
     }
 }

--- a/src/main/java/MusicPlatform/global/provider/JwtProvider.java
+++ b/src/main/java/MusicPlatform/global/provider/JwtProvider.java
@@ -1,0 +1,37 @@
+package MusicPlatform.global.provider;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.expiration_time}")
+    private long ACCESS_TOKEN_EXP_TIME;
+    @Value("${jwt.secret}")
+    private String SECRET;
+
+    public String createToken(String uuid) {
+        Claims claims = Jwts.claims();
+        claims.put("uuid", uuid);
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(ACCESS_TOKEN_EXP_TIME);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(Instant.now()))
+                .setExpiration(Date.from(tokenValidity.toInstant()))
+                .signWith(Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,11 @@ cors:
   allow:
     origins: http://localhost:3000
     methods: GET, POST, PUT, DELETE, PATCH, OPTION
+
+jwt:
+  expiration_time: 604800000 #1000*60*60*24*7; 7일
+  secret: eBDrkWz9FExzSvLdyybd7isbt0X11nxy
+
+cookie:
+  domain: localhost
+  max-age: 604800  # 60*60*24*7, 7일


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #15

## 📝 작업 내용

- JWT 토큰을 생성하고 쿠키로 저장하는 작업을 진행했습니다.
- JWT 토큰 값으로는 사용자(artist)의 uuid가 들어갑니다.  

<br>

- 추가적으로 #17 PR에서 잘못 작업됐었던 일부 코드를 수정했습니다.
  - 사용자 이름 반환이 sub으로 잘못되었던 부분을 name으로 수정했습니다. 
- 회원가입시 기본적으로 사용자 프로필 이미지로 oauth2 서비스 프로필 이미지가 들어가도록 수정했습니다.
- 회원가입시 이미 존재하는 회원인 경우 해당 회원을 반환하도록 수정했습니다. 

