### PR TITLE
Feature/#7 앨범 crud

### DIFF
--- a/src/main/java/MusicPlatform/domain/album/controller/AlbumController.java
+++ b/src/main/java/MusicPlatform/domain/album/controller/AlbumController.java
@@ -1,0 +1,68 @@
+package MusicPlatform.domain.album.controller;
+
+import MusicPlatform.domain.album.service.AlbumService;
+import MusicPlatform.domain.album.service.dto.request.AlbumRequestDto;
+import MusicPlatform.domain.album.service.dto.request.AlbumUpdateRequestDto;
+import MusicPlatform.domain.album.service.dto.response.AlbumGetResponseDto;
+import MusicPlatform.domain.album.service.dto.response.AlbumResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+@Tag(name = "앨범 (Album)")
+public class AlbumController {
+
+    private final AlbumService albumService;
+
+    @PostMapping("/album")
+    @Operation(summary = "앨범 업로드")
+    public ResponseEntity<Void> uploadAlbum(@ModelAttribute @Valid AlbumRequestDto requestDto) {
+        albumService.save(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "엘범 조회")
+    @GetMapping("/album/{uuid}")
+    public ResponseEntity<AlbumGetResponseDto> getByUuid(@PathVariable String uuid) {
+        AlbumGetResponseDto responseDto = albumService.getAlbum(uuid);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @Operation(summary = "특정 아티스트의 엘범 목록 조회")
+    @GetMapping("/artist/{uuid}/album")
+    public ResponseEntity<List<AlbumResponseDto>> getAllByArtist(@PathVariable String uuid) {
+        List<AlbumResponseDto> responseDto = albumService.getAllByArtist(uuid);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @Operation(summary = "앨범 수정")
+    @PatchMapping("/album/{uuid}")
+    public ResponseEntity<Void> updateByUuid(@RequestBody @Valid AlbumUpdateRequestDto requestDto,
+                                             @PathVariable String uuid) {
+        albumService.updateByUuid(requestDto, uuid);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "트랙 삭제")
+    @DeleteMapping("/album/{uuid}")
+    public ResponseEntity<Void> deleteByUuid(@PathVariable String uuid) {
+        albumService.deleteByUuid(uuid);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/MusicPlatform/domain/album/entity/Album.java
+++ b/src/main/java/MusicPlatform/domain/album/entity/Album.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -36,9 +37,25 @@ public class Album extends UuidEntity {
     private LocalDate releaseDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "Profile_ID", nullable = false)
+    @JoinColumn(name = "Profile_ID", nullable = true) //todo: false로 교체한다.
     private Profile profile;
 
     @Column(nullable = false)
     private boolean isDeleted;
+
+    @Builder
+    private Album(String title, String description, String artImage, LocalDate releaseDate, Profile profile) {
+        this.title = title;
+        this.description = description;
+        this.artImage = artImage;
+        this.releaseDate = releaseDate;
+        this.profile = profile;
+        this.isDeleted = false;
+    }
+
+    public void update(String artImage, String title, String description) {
+        this.artImage = artImage;
+        this.title = title;
+        this.description = description;
+    }
 }

--- a/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
+++ b/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
@@ -1,9 +1,17 @@
 package MusicPlatform.domain.album.repository;
 
 import MusicPlatform.domain.album.entity.Album;
+import MusicPlatform.domain.artist.entity.Artist;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AlbumRepository extends JpaRepository<Album, Long> {
     Optional<Album> findByUuid(String uuid);
+    @Query("SELECT t FROM Album t "
+            + "JOIN t.profile p "
+            + "JOIN p.artist a "
+            + "WHERE a = :artist")
+    List<Album> getAllByArtist(Artist artist);
 }

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -4,7 +4,19 @@ import static MusicPlatform.global.error.BusinessError.NOT_FOUND_ALBUM;
 
 import MusicPlatform.domain.album.entity.Album;
 import MusicPlatform.domain.album.repository.AlbumRepository;
+import MusicPlatform.domain.album.service.dto.request.AlbumRequestDto;
+import MusicPlatform.domain.album.service.dto.request.AlbumUpdateRequestDto;
+import MusicPlatform.domain.album.service.dto.response.AlbumGetResponseDto;
+import MusicPlatform.domain.album.service.dto.response.AlbumResponseDto;
+import MusicPlatform.domain.artist.entity.Artist;
+import MusicPlatform.domain.artist.service.ArtistService;
+import MusicPlatform.domain.profile.service.dto.response.ProfileResponseDto;
+import MusicPlatform.domain.track.entity.Track;
+import MusicPlatform.domain.track.repository.dto.response.TrackResponseDto;
+import MusicPlatform.domain.track.service.TrackService;
 import MusicPlatform.global.error.BusinessException;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,10 +27,61 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlbumService {
 
     private final AlbumRepository albumRepository;
+    private final TrackService trackService;
+    private final ArtistService artistService;
 
     @Transactional(readOnly = true)
     public Album getByUuid(String uuid) {
         return albumRepository.findByUuid(uuid)
                 .orElseThrow(() -> new BusinessException(NOT_FOUND_ALBUM));
+    }
+
+    public void save(AlbumRequestDto requestDto) {
+        //todo: s3 이미지 업로드 구현
+        Album album = Album.builder()
+                .artImage("")
+                .title(requestDto.title())
+                .description(requestDto.description())
+                //.profile() //todo 현재 프로필을 가져온다.
+                .releaseDate(LocalDate.now())
+                .build();
+        albumRepository.save(album);
+    }
+
+    @Transactional(readOnly = true)
+    public AlbumGetResponseDto getAlbum(String uuid) {
+        Album album = getByUuid(uuid);
+        List<Track> tracks = trackService.getAllByAlbum(album);
+
+        return AlbumGetResponseDto.builder()
+                .albumResponseDto(AlbumResponseDto.from(album))
+                .trackResponseDtos(tracks.stream()
+                        .map(TrackResponseDto::from)
+                        .toList())
+                .profileResponseDto(ProfileResponseDto.from(album.getProfile()))
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlbumResponseDto> getAllByArtist(String uuid) {
+        Artist artist = artistService.findByUuid(uuid);
+        List<Album> albums = albumRepository.getAllByArtist(artist);
+
+        return albums.stream()
+                .map(AlbumResponseDto::from)
+                .toList();
+    }
+
+    public void updateByUuid(AlbumUpdateRequestDto requestDto, String uuid) {
+        //todo: 내가 업로드한 앨범인지 확인한다.
+        Album album = getByUuid(uuid);
+        //todo: 예전 엘범아트 삭제
+        album.update(requestDto.albumArt(), requestDto.title(), requestDto.description());
+    }
+
+    public void deleteByUuid(String uuid) {
+        //todo: 내가 업로드한 앨범인지 확인한다.
+        Album album = getByUuid(uuid);
+        albumRepository.delete(album);
     }
 }

--- a/src/main/java/MusicPlatform/domain/album/service/dto/request/AlbumRequestDto.java
+++ b/src/main/java/MusicPlatform/domain/album/service/dto/request/AlbumRequestDto.java
@@ -1,0 +1,13 @@
+package MusicPlatform.domain.album.service.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+public record AlbumRequestDto(
+        @NotBlank
+        String albumArt,
+        @NotBlank
+        String title,
+        @Nullable
+        String description
+) {
+}

--- a/src/main/java/MusicPlatform/domain/album/service/dto/request/AlbumUpdateRequestDto.java
+++ b/src/main/java/MusicPlatform/domain/album/service/dto/request/AlbumUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package MusicPlatform.domain.album.service.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+
+public record AlbumUpdateRequestDto(
+        @NotBlank
+        String albumArt,
+        @NotBlank
+        String title,
+        @Nullable
+        String description
+) {
+}

--- a/src/main/java/MusicPlatform/domain/album/service/dto/response/AlbumGetResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/album/service/dto/response/AlbumGetResponseDto.java
@@ -1,0 +1,14 @@
+package MusicPlatform.domain.album.service.dto.response;
+
+import MusicPlatform.domain.profile.service.dto.response.ProfileResponseDto;
+import MusicPlatform.domain.track.repository.dto.response.TrackResponseDto;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AlbumGetResponseDto(
+        AlbumResponseDto albumResponseDto,
+        List<TrackResponseDto> trackResponseDtos,
+        ProfileResponseDto profileResponseDto
+) {
+}

--- a/src/main/java/MusicPlatform/domain/profile/service/dto/response/ProfileResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/profile/service/dto/response/ProfileResponseDto.java
@@ -1,0 +1,19 @@
+package MusicPlatform.domain.profile.service.dto.response;
+
+import MusicPlatform.domain.profile.entity.Profile;
+import lombok.Builder;
+
+@Builder
+public record ProfileResponseDto(
+        String name,
+        String profileImage,
+        Boolean isMain
+) {
+    public static ProfileResponseDto from(Profile profile) {
+        return ProfileResponseDto.builder()
+                .name(profile.getName())
+                .profileImage(profile.getProfileImage())
+                .isMain(profile.isMain())
+                .build();
+    }
+}

--- a/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
+++ b/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
@@ -2,6 +2,7 @@ package MusicPlatform.domain.track.controller;
 
 import MusicPlatform.domain.track.repository.dto.request.TrackRequestDto;
 import MusicPlatform.domain.track.repository.dto.request.TrackUpdateRequestDto;
+import MusicPlatform.domain.track.repository.dto.response.TrackGetResponseDto;
 import MusicPlatform.domain.track.repository.dto.response.TrackResponseDto;
 import MusicPlatform.domain.track.service.TrackService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,7 +32,7 @@ public class TrackController {
     private final TrackService trackService;
 
     @Operation(summary = "트랙 업로드")
-    @PostMapping(value = "album/{uuid}/track")
+    @PostMapping(value = "/album/{uuid}/track")
     public ResponseEntity<Void> uploadTrack(@ModelAttribute @Valid TrackRequestDto requestDto,
                                             @PathVariable String uuid) {
         trackService.save(requestDto, uuid);
@@ -40,15 +41,16 @@ public class TrackController {
 
     @Operation(summary = "트랙 조회")
     @GetMapping("/track/{uuid}")
-    public ResponseEntity<TrackResponseDto> getByUuid(@PathVariable String uuid) {
-        TrackResponseDto responseDto = trackService.getTrack(uuid);
+    public ResponseEntity<TrackGetResponseDto> getByUuid(@PathVariable String uuid) {
+        TrackGetResponseDto responseDto = trackService.getTrack(uuid);
         return ResponseEntity.ok(responseDto);
     }
 
+    @Deprecated
     @Operation(summary = "특정 아티스트의 트랙 목록 조회")
     @GetMapping("/artist/{uuid}/track")
-    public ResponseEntity<List<TrackResponseDto>> getAllByArtist(@PathVariable String uuid) {
-        List<TrackResponseDto> responseDto = trackService.getAllByArtist(uuid);
+    public ResponseEntity<List<TrackGetResponseDto>> getAllByArtist(@PathVariable String uuid) {
+        List<TrackGetResponseDto> responseDto = trackService.getAllByArtist(uuid);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
@@ -1,5 +1,6 @@
 package MusicPlatform.domain.track.repository;
 
+import MusicPlatform.domain.album.entity.Album;
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.track.entity.Track;
 import java.util.List;
@@ -16,4 +17,6 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
             + "JOIN p.artist a "
             + "WHERE a = :artist")
     List<Track> findAllByArtist(Artist artist);
+
+    List<Track> findAllByAlbum(Album album);
 }

--- a/src/main/java/MusicPlatform/domain/track/repository/dto/response/TrackGetResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/dto/response/TrackGetResponseDto.java
@@ -1,0 +1,21 @@
+package MusicPlatform.domain.track.repository.dto.response;
+
+import MusicPlatform.domain.album.service.dto.response.AlbumResponseDto;
+import MusicPlatform.domain.profile.service.dto.response.ProfileResponseDto;
+import MusicPlatform.domain.track.entity.Track;
+import lombok.Builder;
+
+@Builder
+public record TrackGetResponseDto(
+        TrackResponseDto trackResponseDto,
+        AlbumResponseDto albumResponseDto,
+        ProfileResponseDto profileResponseDto
+) {
+    public static TrackGetResponseDto from(Track track) {
+        return TrackGetResponseDto.builder()
+                .trackResponseDto(TrackResponseDto.from(track))
+                .albumResponseDto(AlbumResponseDto.from(track.getAlbum()))
+                .profileResponseDto(ProfileResponseDto.from(track.getProfile()))
+                .build();
+    }
+}

--- a/src/main/java/MusicPlatform/domain/track/repository/dto/response/TrackResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/dto/response/TrackResponseDto.java
@@ -10,9 +10,7 @@ public record TrackResponseDto(
         String uuid,
         String title,
         String lyric,
-        String artUrl,
-        AlbumResponseDto album,
-        ArtistResponseDto artist
+        String artUrl
 ) {
     public static TrackResponseDto from(Track track) {
         return TrackResponseDto.builder()
@@ -20,8 +18,6 @@ public record TrackResponseDto(
                 .title(track.getTitle())
                 .lyric(track.getLyric())
                 .artUrl(track.getAlbumArt())
-                .album(AlbumResponseDto.from(track.getAlbum()))
-                .artist(ArtistResponseDto.from(track.getArtist()))
                 .build();
     }
 }

--- a/src/main/java/MusicPlatform/domain/track/service/TrackService.java
+++ b/src/main/java/MusicPlatform/domain/track/service/TrackService.java
@@ -10,7 +10,7 @@ import MusicPlatform.domain.track.entity.Track;
 import MusicPlatform.domain.track.repository.TrackRepository;
 import MusicPlatform.domain.track.repository.dto.request.TrackRequestDto;
 import MusicPlatform.domain.track.repository.dto.request.TrackUpdateRequestDto;
-import MusicPlatform.domain.track.repository.dto.response.TrackResponseDto;
+import MusicPlatform.domain.track.repository.dto.response.TrackGetResponseDto;
 import MusicPlatform.global.error.BusinessException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,16 +21,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class TrackService {
-
     private final TrackRepository trackRepository;
     private final AlbumService albumService;
     private final ArtistService artistService;
-
 
     @Transactional(readOnly = true)
     public Track getByUuid(String uuid) {
         return trackRepository.findByUuid(uuid).orElseThrow(() ->
                 new BusinessException(NOT_FOUND_TRACK));
+    }
+
+
+    @Transactional(readOnly = true)
+    public List<Track> getAllByAlbum(Album album) {
+        return trackRepository.findAllByAlbum(album);
     }
 
     public void save(TrackRequestDto requestDto, String albumUuid) {
@@ -49,17 +53,18 @@ public class TrackService {
     }
 
     @Transactional(readOnly = true)
-    public TrackResponseDto getTrack(String uuid) {
+    public TrackGetResponseDto getTrack(String uuid) {
         Track track = getByUuid(uuid);
-        return TrackResponseDto.from(track);
+        return TrackGetResponseDto.from(track);
     }
 
+    @Deprecated // 앨범의 getAllByArtist로 대체한다.
     @Transactional(readOnly = true)
-    public List<TrackResponseDto> getAllByArtist(String artistUuid) {
+    public List<TrackGetResponseDto> getAllByArtist(String artistUuid) {
         Artist artist = artistService.findByUuid(artistUuid);
         List<Track> tracks = trackRepository.findAllByArtist(artist);
         return tracks.stream()
-                .map(TrackResponseDto::from)
+                .map(TrackGetResponseDto::from)
                 .toList();
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #7

## 📝 작업 내용

앨범의 CRUD를 구현하였습니다. 
- 앨범 업로드
- 앨범 페이지 조회
- 특정 회원의 앨범 목록 조회
- 앨범 수정 (이후 인가 추가)
- 앨범 삭제 (이후 인가 추가)

또한 좀 더 재사용성 높고, 개방폐쇄적인 DTO를 만들기 위해 기존 트랙(#12) 의 DTO를 일부 수정하였습니다. 

