### PR TITLE
Fix/#30 배포 서버에서 swagger에 접속할수 없는 문제를 해결한다

### DIFF
--- a/src/main/java/MusicPlatform/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/MusicPlatform/global/config/swagger/SwaggerConfig.java
@@ -3,21 +3,32 @@ package MusicPlatform.global.config.swagger;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    @Value("${server.api}")
+    private String api;
+
     @Bean
     public OpenAPI openAPI() {
         Info info = new Info()
                 .title("Untitled API Document")
                 .version("v0.1.0-alpha");
+
+        Server server = new Server();
+        server.setUrl(api);
+
         return new OpenAPI()
                 .components(new Components())
-                .info(info);
+                .info(info)
+                .servers(List.of(server));
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:
-    path: swagger-ui.html
+    path: /swagger-ui
     tags-sorter: alpha
     operations-sorter: alpha
   api-docs:
@@ -57,4 +57,6 @@ springdoc:
 
 server:
   front: https://soundforest.kro.kr
+  api: https://soundforest.kro.kr/v1
   error-page: https://soundforest.kro.kr/error
+  


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #30

## 📝 작업 내용

### 문제 1
#30 참고
스웨거 내에서 v1 경로가 아닌 front 경로로 리다이렉션되며 404 오류가 발생하는 문제를 해결했습니다. 아래는 수정된 NGINX 코드입니다.
```
    location /api-docs {
        proxy_pass http://spring/api-docs;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }
```


### 문제2
<img width="901" alt="image" src="https://github.com/user-attachments/assets/14b0f8df-d891-45eb-821a-0c4ea362e597">
문제1을 수정하는 것으로 swagger에 정상적으로 접속할수 있었으나, 스웨거 내에서 api 테스트시 위와 같은 CORS오류가 발생했습니다. 
단순 http로 api를 호출하는 것 뿐만 아니라 v1 패스가 적용되지 않았음을 확인할 수 있었습니다.
따라서 swaggerConfig에서 server 경로 설정을 해주었습니다.
