### PR TITLE
Feature/#34 role을 생성한다

### DIFF
--- a/src/main/java/MusicPlatform/domain/artist/controller/ArtistController.java
+++ b/src/main/java/MusicPlatform/domain/artist/controller/ArtistController.java
@@ -1,0 +1,34 @@
+package MusicPlatform.domain.artist.controller;
+
+import MusicPlatform.domain.artist.service.ArtistService;
+import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/artist")
+public class ArtistController {
+
+    private final ArtistService artistService;
+
+    @PreAuthorize("hasAnyAuthority('ROLE_USER')")
+    @Operation(summary = "현재 로그인한 회원의 정보 조회")
+    @GetMapping
+    public ResponseEntity<ArtistResponseDto> getMyInfo() {
+        ArtistResponseDto responseDto = artistService.getMyInfo();
+        return ResponseEntity.ok(responseDto);
+    }
+
+//    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN')")
+//    @Operation(summary = "ADMIN 권환 확인")
+//    @GetMapping("/admin")
+//    public ResponseEntity<Void> isAdmin() {
+//        return ResponseEntity.noContent().build();
+//    }
+}

--- a/src/main/java/MusicPlatform/domain/artist/entity/Artist.java
+++ b/src/main/java/MusicPlatform/domain/artist/entity/Artist.java
@@ -3,6 +3,8 @@ package MusicPlatform.domain.artist.entity;
 import MusicPlatform.global.entity.UuidEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -31,15 +33,20 @@ public class Artist extends UuidEntity {
     @Column(nullable = false)
     private String artistImage;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
     @Column(nullable = false)
     private boolean isDeleted;
 
     @Builder
-    private Artist(String name, String email, String provider, String artistImage) {
+    private Artist(String name, String email, String provider, String artistImage, Role role) {
         this.name = name;
         this.email = email;
         this.provider = provider;
         this.artistImage = artistImage;
+        this.role = role;
         this.isDeleted = false;
     }
 }

--- a/src/main/java/MusicPlatform/domain/artist/entity/Role.java
+++ b/src/main/java/MusicPlatform/domain/artist/entity/Role.java
@@ -1,0 +1,6 @@
+package MusicPlatform.domain.artist.entity;
+
+public enum Role {
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
@@ -1,16 +1,21 @@
 package MusicPlatform.domain.artist.service;
 
+import static MusicPlatform.domain.artist.entity.Role.ROLE_USER;
 import static MusicPlatform.global.error.BusinessError.NOT_FOUND_ARTIST;
 
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.repository.ArtistRepository;
+import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
 import MusicPlatform.domain.oauth2.entity.ProviderUser;
 import MusicPlatform.domain.profile.service.ProfileService;
 import MusicPlatform.global.error.BusinessException;
+import MusicPlatform.global.helper.AuthorizationHelper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -18,6 +23,7 @@ public class ArtistService {
 
     private final ArtistRepository artistRepository;
     private final ProfileService profileService;
+    private final AuthorizationHelper authorizationHelper;
 
     @Transactional(readOnly = true)
     public Artist findByUuid(String uuid) {
@@ -25,7 +31,7 @@ public class ArtistService {
                 new BusinessException(NOT_FOUND_ARTIST));
     }
 
-    public Artist register(String registrationId, ProviderUser providerUser) {
+    public Artist registerOrReturn(String registrationId, ProviderUser providerUser) {
         Artist existArtist = artistRepository.findByEmail(providerUser.getEmail());
         if (existArtist != null) { // 이미 가입한 회원 검증
             return existArtist;
@@ -36,10 +42,18 @@ public class ArtistService {
                 .name(providerUser.getName())
                 .provider(registrationId)
                 .artistImage(providerUser.getPicture()) //todo 기본 이미지 등록
+                .role(ROLE_USER)
                 .build();
 
         artistRepository.save(artist);
         profileService.createProfile(artist);
         return artist;
+    }
+
+    public ArtistResponseDto getMyInfo() {
+        String uuid = authorizationHelper.getMyUuid();
+        log.info("uuid = " + uuid);
+        Artist artist = findByUuid(uuid);
+        return ArtistResponseDto.from(artist);
     }
 }

--- a/src/main/java/MusicPlatform/domain/artist/service/dto/response/ArtistResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/dto/response/ArtistResponseDto.java
@@ -1,12 +1,14 @@
 package MusicPlatform.domain.artist.service.dto.response;
 
 import MusicPlatform.domain.artist.entity.Artist;
+import MusicPlatform.domain.artist.entity.Role;
 import lombok.Builder;
 
 @Builder
 public record ArtistResponseDto(
         String uuid,
         String name,
+        Role role,
         String email,
         String artistImage
 ) {
@@ -14,6 +16,7 @@ public record ArtistResponseDto(
         return ArtistResponseDto.builder()
                 .uuid(artist.getUuid())
                 .name(artist.getName())
+                .role(artist.getRole())
                 .email(artist.getEmail())
                 .artistImage(artist.getArtistImage())
                 .build();

--- a/src/main/java/MusicPlatform/domain/oauth2/adapter/AuthenticationAdapter.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/adapter/AuthenticationAdapter.java
@@ -1,5 +1,8 @@
 package MusicPlatform.domain.oauth2.adapter;
 
+import MusicPlatform.domain.artist.entity.Role;
+
 public interface AuthenticationAdapter {
     String getUuid();
+    Role getRole();
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/entity/GoogleUser.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/entity/GoogleUser.java
@@ -1,14 +1,9 @@
 package MusicPlatform.domain.oauth2.entity;
 
-import MusicPlatform.domain.artist.entity.Role;
-import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
-public class GoogleUser extends OAuth2ProviderUser implements AuthenticationAdapter {
-
-    private String uuid;
-    private Role role;
+public class GoogleUser extends OAuth2ProviderUser{
 
     public GoogleUser(OAuth2User oAuth2User, ClientRegistration clientRegistration) {
         super(oAuth2User.getAttributes(), oAuth2User, clientRegistration);
@@ -27,20 +22,5 @@ public class GoogleUser extends OAuth2ProviderUser implements AuthenticationAdap
     @Override
     public String getPicture() {
         return getAttributes().get("picture").toString();
-    }
-
-    @Override
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    @Override
-    public String getUuid() {
-        return this.uuid;
-    }
-
-    @Override
-    public Role getRole() {
-        return this.role;
     }
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/entity/GoogleUser.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/entity/GoogleUser.java
@@ -1,5 +1,6 @@
 package MusicPlatform.domain.oauth2.entity;
 
+import MusicPlatform.domain.artist.entity.Role;
 import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -7,6 +8,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class GoogleUser extends OAuth2ProviderUser implements AuthenticationAdapter {
 
     private String uuid;
+    private Role role;
 
     public GoogleUser(OAuth2User oAuth2User, ClientRegistration clientRegistration) {
         super(oAuth2User.getAttributes(), oAuth2User, clientRegistration);
@@ -35,5 +37,10 @@ public class GoogleUser extends OAuth2ProviderUser implements AuthenticationAdap
     @Override
     public String getUuid() {
         return this.uuid;
+    }
+
+    @Override
+    public Role getRole() {
+        return this.role;
     }
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/entity/OAuth2ProviderUser.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/entity/OAuth2ProviderUser.java
@@ -1,5 +1,7 @@
 package MusicPlatform.domain.oauth2.entity;
 
+import MusicPlatform.domain.artist.entity.Role;
+import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -11,7 +13,10 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 /**
  * 모든 서비스 제공자가 동일하게 제공하는 속성들
  */
-public abstract class OAuth2ProviderUser implements ProviderUser {
+public abstract class OAuth2ProviderUser implements ProviderUser, AuthenticationAdapter {
+
+    private String uuid;
+    private Role role;
 
     private final Map<String, Object> attributes;
     private final OAuth2User oAuth2User;
@@ -41,13 +46,36 @@ public abstract class OAuth2ProviderUser implements ProviderUser {
 
     @Override
     public List<? extends GrantedAuthority> getAuthorities() {
-        return oAuth2User.getAuthorities().stream()
-                .map(authority -> new SimpleGrantedAuthority(authority.getAuthority()))
-                .toList();
+        return List.of(new SimpleGrantedAuthority(this.role.name()));
     }
 
     @Override
     public Map<String, Object> getAttributes() {
         return attributes;
+    }
+
+    @Override
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public String getUuid() {
+        return this.uuid;
+    }
+
+    @Override
+    public String toString() {
+        return this.uuid;
+    }
+
+    @Override
+    public Role getRole() {
+        return this.role;
+    }
+
+    @Override
+    public void setRole(Role role) {
+        this.role = role;
     }
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/entity/ProviderUser.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/entity/ProviderUser.java
@@ -1,5 +1,6 @@
 package MusicPlatform.domain.oauth2.entity;
 
+import MusicPlatform.domain.artist.entity.Role;
 import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
 import java.util.List;
 import java.util.Map;
@@ -7,15 +8,16 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 public interface ProviderUser extends OAuth2User {
+
+    String getUuid();
+    void setUuid(String uuid);
+    void setRole(Role role);
     String getId();
     String getName();
     String getPassword();
     String getEmail();
     String getProvider();
     String getPicture();
-
     List<? extends GrantedAuthority> getAuthorities();
     Map<String, Object> getAttributes();
-    void setUuid(String uuid);
-
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
@@ -1,5 +1,6 @@
 package MusicPlatform.domain.oauth2.service;
 
+import MusicPlatform.domain.artist.entity.Role;
 import MusicPlatform.global.provider.JwtProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -37,8 +38,8 @@ public class CookieService {
         return cookie;
     }
 
-    public void authenticate(String uuid, HttpServletResponse response) {
-        String accessToken = jwtProvider.createToken(uuid);
+    public void authenticate(String uuid, Role role, HttpServletResponse response) {
+        String accessToken = jwtProvider.createToken(uuid, role);
         response.addCookie(this.makeAccessTokenCookie(accessToken));
         
         log.info("쿠키 저장 = " + response.getHeader("Set-Cookie"));

--- a/src/main/java/MusicPlatform/domain/oauth2/service/OAuth2UserService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/OAuth2UserService.java
@@ -27,9 +27,10 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest); //사용자 정보 반환
         ProviderUser providerUser = providerUser(clientRegistration, oAuth2User);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        Artist artist = artistService.register(registrationId, providerUser);
+        Artist artist = artistService.registerOrReturn(registrationId, providerUser);
         log.info("회원가입 = " + providerUser.getName());
         providerUser.setUuid(artist.getUuid());
+        providerUser.setRole(artist.getRole());
         return providerUser;
     }
 

--- a/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -13,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class Oauth2ClientConfig {
 

--- a/src/main/java/MusicPlatform/global/handler/LoginSuccessHandler.java
+++ b/src/main/java/MusicPlatform/global/handler/LoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package MusicPlatform.global.handler;
 
+import MusicPlatform.domain.artist.entity.Role;
 import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
 import MusicPlatform.domain.oauth2.service.CookieService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,6 +33,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         AuthenticationAdapter authenticationAdapter = (AuthenticationAdapter) authentication.getPrincipal();
 
         String uuid = authenticationAdapter.getUuid();
+        Role role = authenticationAdapter.getRole();
 
         cookieService.authenticate(uuid, response);
 

--- a/src/main/java/MusicPlatform/global/handler/LoginSuccessHandler.java
+++ b/src/main/java/MusicPlatform/global/handler/LoginSuccessHandler.java
@@ -35,7 +35,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         String uuid = authenticationAdapter.getUuid();
         Role role = authenticationAdapter.getRole();
 
-        cookieService.authenticate(uuid, response);
+        cookieService.authenticate(uuid, role, response);
 
         String url = UriComponentsBuilder.fromUriString(domain)
                 .path("")

--- a/src/main/java/MusicPlatform/global/provider/JwtProvider.java
+++ b/src/main/java/MusicPlatform/global/provider/JwtProvider.java
@@ -1,5 +1,6 @@
 package MusicPlatform.global.provider;
 
+import MusicPlatform.domain.artist.entity.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -21,13 +22,14 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String SECRET;
 
-    public String createToken(String uuid) {
+    public String createToken(String uuid, Role role) {
         Claims claims = Jwts.claims();
-        claims.put("uuid", uuid);
+        claims.put("role", role);
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime tokenValidity = now.plusSeconds(ACCESS_TOKEN_EXP_TIME);
 
         return Jwts.builder()
+                .setSubject(uuid)
                 .setClaims(claims)
                 .setIssuedAt(Date.from(Instant.now()))
                 .setExpiration(Date.from(tokenValidity.toInstant()))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #34 
#5 

## 📝 작업 내용

Artist에 대한 Role 추가와, Role에 따른 Authorization 제한 기능을 구현했습니다. 
제 실수로 #36 와 코드가 섞였습니다ㅠㅠ 

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/d7192de7-c625-4976-ac53-203522888b43">

-  @PreAuthorize을 통한 개별 Api 접근 제한을 구현한다. 
    - 현재 뮤직 플랫폼은 일부 api(Get등)은 비회원 또한 접근 가능하도록 개발되어 있습니다.
    - 회원/비회원을 제외한 다른 역할이 추가될 예정이 없어서 인가가 아닌 인증만으로 api 접근 제한을 진행할 예정이었으나, 인증만으로는 일부 api에 대해서만 접근 제한을 거는 것이 어려웠습니다.
    - 따라서 회원인 경우 ROLE_USER 역할을 부여해, 인가를 사용하여 비회원에 대한 일부 Api 접근 제한을 구현하였습니다.
- Authorities을 수정한다.
    - Role을 추가함에 따라 role로 Authorities를 구별할 수 있도록 수정하였습니다.
- cookie 정보에 role을 추가한다. 
    - cookie에 uuid뿐만 아니라 role이 함께 저장되도록 수정하였습니다. 


### 이후 수행되어야 할 작업
- 인가/인증 여부에 따른 Exception 처리가 추가되어야합니다! 다른 이슈로 추가 작업할 예정입니다. 
- 현재 서버에 띄어져있는 백엔드 서버가 로그인 이후 항상 프론트 도메인으로 리다이렉션됨에 따라, 프론트가 로컬에서 로그인하기 어려운 상황입니다. 따라서 getMyInfo를 제외한 api에는 아직 접근 제한을 추가하지 않았습니다. 프론트의 로컬 로그인 문제가 해결됨에 따라 PR을 재오픈하여 추가하거나, 새로 이슈를 파도록 하겠습니다. 
