### PR TITLE
Feature/#27 jwt 토큰 필터링 및 인증/인가 권한 실패 처리

### DIFF
--- a/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
@@ -4,8 +4,10 @@ import MusicPlatform.domain.artist.entity.Role;
 import MusicPlatform.global.provider.JwtProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,10 +40,10 @@ public class CookieService {
         return cookie;
     }
 
-    public void authenticate(String uuid, Role role, HttpServletResponse response) {
+    public void authenticate(String uuid, List<? extends GrantedAuthority> role, HttpServletResponse response) {
         String accessToken = jwtProvider.createToken(uuid, role);
         response.addCookie(this.makeAccessTokenCookie(accessToken));
         
-        log.info("쿠키 저장 = " + response.getHeader("Set-Cookie"));
+        log.info("쿠키 저장 = " + accessToken);
     }
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
@@ -1,7 +1,5 @@
 package MusicPlatform.domain.oauth2.service;
 
-import MusicPlatform.domain.artist.entity.Role;
-import MusicPlatform.global.provider.JwtProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -19,7 +17,7 @@ public class CookieService {
     // private String domain;
     @Value("${cookie.max-age}")
     private int maxAge;
-    private final JwtProvider jwtProvider;
+    private final JwtService jwtService;
 
     public Cookie makeAccessTokenCookie(String token) {
         return this.makeCookie("access_token", token, maxAge);
@@ -41,7 +39,7 @@ public class CookieService {
     }
 
     public void authenticate(String uuid, List<? extends GrantedAuthority> role, HttpServletResponse response) {
-        String accessToken = jwtProvider.createToken(uuid, role);
+        String accessToken = jwtService.createToken(uuid, role);
         response.addCookie(this.makeAccessTokenCookie(accessToken));
         
         log.info("쿠키 저장 = " + accessToken);

--- a/src/main/java/MusicPlatform/domain/oauth2/service/JwtService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/JwtService.java
@@ -1,4 +1,4 @@
-package MusicPlatform.global.provider;
+package MusicPlatform.domain.oauth2.service;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.*;
@@ -13,10 +13,10 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
-public class JwtProvider {
+@Service
+public class JwtService {
 
     @Value("${jwt.expiration_time}")
     private long ACCESS_TOKEN_EXP_TIME;

--- a/src/main/java/MusicPlatform/global/config/cors/CorsConfig.java
+++ b/src/main/java/MusicPlatform/global/config/cors/CorsConfig.java
@@ -1,12 +1,15 @@
 package MusicPlatform.global.config.cors;
 
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-public class CorsConfig implements WebMvcConfigurer {
+public class CorsConfig {
 
     @Value(value = "${cors.allow.origins}")
     private String[] allowedOrigins;
@@ -14,13 +17,16 @@ public class CorsConfig implements WebMvcConfigurer {
     @Value(value = "${cors.allow.methods}")
     private String[] allowedMethods;
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins(allowedOrigins)
-                .allowedMethods(allowedMethods)
-                .allowedHeaders("Origin", "Content-Type", "Accept", "Authorization")
-                .allowCredentials(true)
-                .maxAge(3600);
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(allowedOrigins));
+        config.setAllowedMethods(List.of(allowedMethods));
+        config.setAllowedHeaders(List.of("Origin", "Content-Type", "Accept", "Authorization"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L); // preflight 요청에 대한 응답 캐싱 (1시간)
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
@@ -3,6 +3,7 @@ package MusicPlatform.global.config.security;
 import MusicPlatform.domain.oauth2.service.OAuth2UserService;
 import MusicPlatform.global.handler.LoginSuccessHandler;
 import MusicPlatform.global.handler.OauthAccessDeniedHandler;
+import MusicPlatform.global.handler.OauthAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +23,7 @@ public class Oauth2ClientConfig {
     private final OAuth2UserService oAuth2UserService;
     private final LoginSuccessHandler loginSuccessHandler;
     private final OauthAccessDeniedHandler oauthAccessDeniedHandler;
+    private final OauthAuthenticationEntryPoint oauthAuthenticationEntryPoint;
 
     @Value(value = "${server.error-page}")
     private String errorPage;
@@ -43,6 +45,7 @@ public class Oauth2ClientConfig {
 
         http.exceptionHandling(exception -> exception
                 .accessDeniedHandler(oauthAccessDeniedHandler)
+                .authenticationEntryPoint(oauthAuthenticationEntryPoint)
         );
 
         return http.build();

--- a/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
@@ -3,6 +3,7 @@ package MusicPlatform.global.config.security;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 import MusicPlatform.domain.oauth2.service.OAuth2UserService;
+import MusicPlatform.global.config.cors.CorsConfig;
 import MusicPlatform.global.filter.JwtAuthorizationFilter;
 import MusicPlatform.global.handler.LoginSuccessHandler;
 import MusicPlatform.global.handler.OauthAccessDeniedHandler;
@@ -24,6 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class Oauth2ClientConfig {
 
+    private final CorsConfig corsConfig;
     private final OAuth2UserService oAuth2UserService;
     private final LoginSuccessHandler loginSuccessHandler;
     private final OauthAccessDeniedHandler oauthAccessDeniedHandler;
@@ -40,7 +42,7 @@ public class Oauth2ClientConfig {
         );
 
         http.csrf(AbstractHttpConfigurer::disable);
-        http.cors(AbstractHttpConfigurer::disable);
+        http.cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource())); // CORS 설정 활성화
 
         http.sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(STATELESS));
 

--- a/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
@@ -3,7 +3,6 @@ package MusicPlatform.global.config.security;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 import MusicPlatform.domain.oauth2.service.OAuth2UserService;
-import MusicPlatform.global.config.cors.CorsConfig;
 import MusicPlatform.global.filter.JwtAuthorizationFilter;
 import MusicPlatform.global.handler.LoginSuccessHandler;
 import MusicPlatform.global.handler.OauthAccessDeniedHandler;
@@ -25,7 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class Oauth2ClientConfig {
 
-    private final CorsConfig corsConfig;
+    private final SecurityCorsConfig corsConfig;
     private final OAuth2UserService oAuth2UserService;
     private final LoginSuccessHandler loginSuccessHandler;
     private final OauthAccessDeniedHandler oauthAccessDeniedHandler;

--- a/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
@@ -1,5 +1,7 @@
 package MusicPlatform.global.config.security;
 
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
 import MusicPlatform.domain.oauth2.service.OAuth2UserService;
 import MusicPlatform.global.filter.JwtAuthorizationFilter;
 import MusicPlatform.global.handler.LoginSuccessHandler;
@@ -40,13 +42,15 @@ public class Oauth2ClientConfig {
         http.csrf(AbstractHttpConfigurer::disable);
         http.cors(AbstractHttpConfigurer::disable);
 
+        http.sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(STATELESS));
+
         http.oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userService(oAuth2UserService))
                 .successHandler(loginSuccessHandler)
                 .failureUrl(errorPage)
         );
 
-        http.addFilterAfter(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
 
         http.exceptionHandling(exception -> exception
                 .accessDeniedHandler(oauthAccessDeniedHandler)

--- a/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
@@ -1,6 +1,7 @@
 package MusicPlatform.global.config.security;
 
 import MusicPlatform.domain.oauth2.service.OAuth2UserService;
+import MusicPlatform.global.filter.JwtAuthorizationFilter;
 import MusicPlatform.global.handler.LoginSuccessHandler;
 import MusicPlatform.global.handler.OauthAccessDeniedHandler;
 import MusicPlatform.global.handler.OauthAuthenticationEntryPoint;
@@ -13,6 +14,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -24,6 +26,7 @@ public class Oauth2ClientConfig {
     private final LoginSuccessHandler loginSuccessHandler;
     private final OauthAccessDeniedHandler oauthAccessDeniedHandler;
     private final OauthAuthenticationEntryPoint oauthAuthenticationEntryPoint;
+    private final JwtAuthorizationFilter jwtAuthorizationFilter;
 
     @Value(value = "${server.error-page}")
     private String errorPage;
@@ -42,6 +45,8 @@ public class Oauth2ClientConfig {
                 .successHandler(loginSuccessHandler)
                 .failureUrl(errorPage)
         );
+
+        http.addFilterAfter(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
 
         http.exceptionHandling(exception -> exception
                 .accessDeniedHandler(oauthAccessDeniedHandler)

--- a/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/Oauth2ClientConfig.java
@@ -2,6 +2,7 @@ package MusicPlatform.global.config.security;
 
 import MusicPlatform.domain.oauth2.service.OAuth2UserService;
 import MusicPlatform.global.handler.LoginSuccessHandler;
+import MusicPlatform.global.handler.OauthAccessDeniedHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +21,7 @@ public class Oauth2ClientConfig {
 
     private final OAuth2UserService oAuth2UserService;
     private final LoginSuccessHandler loginSuccessHandler;
+    private final OauthAccessDeniedHandler oauthAccessDeniedHandler;
 
     @Value(value = "${server.error-page}")
     private String errorPage;
@@ -34,10 +36,13 @@ public class Oauth2ClientConfig {
         http.cors(AbstractHttpConfigurer::disable);
 
         http.oauth2Login(oauth2 -> oauth2
-                .userInfoEndpoint(userInfoEndpointConfig ->
-                        userInfoEndpointConfig.userService(oAuth2UserService))
+                .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userService(oAuth2UserService))
                 .successHandler(loginSuccessHandler)
                 .failureUrl(errorPage)
+        );
+
+        http.exceptionHandling(exception -> exception
+                .accessDeniedHandler(oauthAccessDeniedHandler)
         );
 
         return http.build();

--- a/src/main/java/MusicPlatform/global/config/security/SecurityCorsConfig.java
+++ b/src/main/java/MusicPlatform/global/config/security/SecurityCorsConfig.java
@@ -1,4 +1,4 @@
-package MusicPlatform.global.config.cors;
+package MusicPlatform.global.config.security;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +9,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-public class CorsConfig {
+public class SecurityCorsConfig {
 
     @Value(value = "${cors.allow.origins}")
     private String[] allowedOrigins;

--- a/src/main/java/MusicPlatform/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/MusicPlatform/global/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,18 @@
+package MusicPlatform.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+    }
+}

--- a/src/main/java/MusicPlatform/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/MusicPlatform/global/filter/JwtAuthorizationFilter.java
@@ -1,6 +1,6 @@
 package MusicPlatform.global.filter;
 
-import MusicPlatform.global.provider.JwtProvider;
+import MusicPlatform.domain.oauth2.service.JwtService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -23,7 +23,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
-    private final JwtProvider jwtProvider;
+    private final JwtService jwtService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -35,7 +35,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         }
 
         String token = header.replace("Bearer ", "");
-        Claims claims = jwtProvider.validateToken(token);
+        Claims claims = jwtService.validateToken(token);
 
         String uuid = claims.getSubject();
         List<?> rawAuthority = (List<?>) claims.get("authority");

--- a/src/main/java/MusicPlatform/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/MusicPlatform/global/filter/JwtAuthorizationFilter.java
@@ -1,18 +1,51 @@
 package MusicPlatform.global.filter;
 
+import MusicPlatform.global.provider.JwtProvider;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.replace("Bearer ", "");
+        Claims claims = jwtProvider.validateToken(token);
+
+        String uuid = claims.getSubject();
+        List<?> rawAuthority = (List<?>) claims.get("authority");
+        List<? extends GrantedAuthority> authorities = rawAuthority.stream()
+                .map(auth -> new SimpleGrantedAuthority(auth.toString()))
+                .toList();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(uuid, null, authorities);
+        log.info("authentication uuid = " + authentication.getPrincipal().toString());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response); //다음 필터로 전달
     }
 }

--- a/src/main/java/MusicPlatform/global/handler/LoginSuccessHandler.java
+++ b/src/main/java/MusicPlatform/global/handler/LoginSuccessHandler.java
@@ -1,16 +1,17 @@
 package MusicPlatform.global.handler;
 
-import MusicPlatform.domain.artist.entity.Role;
-import MusicPlatform.domain.oauth2.adapter.AuthenticationAdapter;
+import MusicPlatform.domain.oauth2.entity.OAuth2ProviderUser;
 import MusicPlatform.domain.oauth2.service.CookieService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -30,10 +31,10 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
 
-        AuthenticationAdapter authenticationAdapter = (AuthenticationAdapter) authentication.getPrincipal();
+        OAuth2ProviderUser user = (OAuth2ProviderUser) authentication.getPrincipal();
 
-        String uuid = authenticationAdapter.getUuid();
-        Role role = authenticationAdapter.getRole();
+        String uuid = user.getUuid();
+        List<? extends GrantedAuthority> role = user.getAuthorities();
 
         cookieService.authenticate(uuid, role, response);
 

--- a/src/main/java/MusicPlatform/global/handler/OauthAccessDeniedHandler.java
+++ b/src/main/java/MusicPlatform/global/handler/OauthAccessDeniedHandler.java
@@ -1,16 +1,9 @@
 package MusicPlatform.global.handler;
 
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.DefaultRedirectStrategy;
-import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/MusicPlatform/global/handler/OauthAccessDeniedHandler.java
+++ b/src/main/java/MusicPlatform/global/handler/OauthAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package MusicPlatform.global.handler;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * 로그인 상태로 권한을 가지지 않은 api에 접근할시 동작합니다.
+ */
+
+@Component
+public class OauthAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/MusicPlatform/global/handler/OauthAuthenticationEntryPoint.java
+++ b/src/main/java/MusicPlatform/global/handler/OauthAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package MusicPlatform.global.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.stereotype.Component;
+
+/**
+ * 미로그인 상태로 권한이 필요한 api에 접근할 시 동작합니다.
+ */
+
+@Component
+public class OauthAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+    @Value(value = "${server.login-page}")
+    private String loginPage;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        redirectStrategy.sendRedirect(request,response,loginPage + "?exception=" + authException.getMessage());
+    }
+}

--- a/src/main/java/MusicPlatform/global/provider/JwtProvider.java
+++ b/src/main/java/MusicPlatform/global/provider/JwtProvider.java
@@ -1,17 +1,17 @@
 package MusicPlatform.global.provider;
 
-import MusicPlatform.domain.artist.entity.Role;
-import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,15 +22,18 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String SECRET;
 
-    public String createToken(String uuid, Role role) {
-        Claims claims = Jwts.claims();
-        claims.put("role", role);
+    public String createToken(String uuid, List<? extends GrantedAuthority> authorities) {
+        List<String> roles = authorities.stream()
+                .map(GrantedAuthority::getAuthority)  // 권한을 String으로 변환
+                .toList();
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("authority", roles);
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime tokenValidity = now.plusSeconds(ACCESS_TOKEN_EXP_TIME);
 
         return Jwts.builder()
+                .setClaims(claims) // setClaims와 setSubject 순서 지킬것
                 .setSubject(uuid)
-                .setClaims(claims)
                 .setIssuedAt(Date.from(Instant.now()))
                 .setExpiration(Date.from(tokenValidity.toInstant()))
                 .signWith(Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)

--- a/src/main/java/MusicPlatform/global/provider/JwtProvider.java
+++ b/src/main/java/MusicPlatform/global/provider/JwtProvider.java
@@ -1,5 +1,6 @@
 package MusicPlatform.global.provider;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -38,5 +39,17 @@ public class JwtProvider {
                 .setExpiration(Date.from(tokenValidity.toInstant()))
                 .signWith(Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public Claims validateToken(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8)))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (JwtException e) {
+            throw new JwtException("유효하지 않은 토큰입니다.");
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,4 +72,6 @@ server:
   front: https://soundforest.kro.kr
   api: https://soundforest.kro.kr/v1
   error-page: https://soundforest.kro.kr/error
+  login-page: https://soundforest.kro.kr
+
   


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #27 #38 

## 📝 작업 내용

인증/인가 실패같은 경우 ExceptionAdvice를 통해 에러 메세지를 처리하려 했는데 AccessDeniedException으로 ExceptionAdvice을 사용할 경우 ExceptionAdvice가 먼저 에러를 캐치하여 handler가 실행되지 않더라구요. 그래서 Advice는 사용하지 않고 handler에서 미가공된 에러 메세지를 전달하는 식으로 구현했습니다. 
(handler단에서 AccessDeniedException대신 BussinessException이나 그 외의 커스텀 에러를 throw하는 방법도 있긴 한데... BussinessException은 성격에 맞지 않는 것 같고 인가 실패만을 위한 커스텀 에러를 만들기는 좀 그래서 이렇게 구현했습니다.)

``` java
        http.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);

        http.exceptionHandling(exception -> exception
                .accessDeniedHandler(oauthAccessDeniedHandler)
                .authenticationEntryPoint(oauthAuthenticationEntryPoint)
        );
```
### 인증/인가 권한 실패 처리
- AccessDeniedHandler 구현
  - 인가 실패시 실행됩니다. 
  - ErrorResponse로 SC_FORBIDDEN을 리턴합니다. 
- AuthenticationEntryPoint 구현
  - 인증 실패시 실행됩니다. 
  - PreAuthorize가 걸려있는 api에 대한 요청이더라도 인증이 되어있지 않은 상태라면 AuthenticationEntryPoint가 실행됩니다.
  - 동작시 사용자를 로그인 페이지로 리다이렉션 시키며 param으로 Exception을 전달합니다.
    - 현재 따로 로그인 페이지가 구현되어있지 않은만큼 (페이지가 아닌 모달을 사용함) root 페이지로 리다이렉션 시켰습니다.
    - 원래 리다이렉션 후에 throw를 하려 했으나 리다이렉션으로 인해 응답이 클라이언트로 전달된 후라 리다이렉션과 throw를 동시 발생시킬수 없었습니다. 

### JWT 토큰 필터링
- 세션을 STATELESS하게 수정하였습니다. 이제 각 요청이 하나의 authentication을 나눠쓰지 않고, 요청마다 각각 authentication을 설정합니다. 
- 프론트의 Authorization 헤더에서 토큰을 받아와 검증합니다.
- authentication의 principle로는 uuid를 지정했습니다.  

### 기존 독립적이었던 Cors 설정을 Security Cors 설정으로 수정
- 기존 Security와는 별개로 Cors 설정을 하고있던 상태였습니다.
- 그러나 해당 방식은 Security 내부의 인증과 연동되지 않는것으로 추측됩니다. (JWT 토큰 필터가 적용되자 Cors에러 발생)
- 따라서 Security의 Cors 설정을 사용하는 것으로 변경되었습니다. 