### PR TITLE
Feature/#16 현재 사용중인 profile 정보를 관리한다

### DIFF
--- a/src/main/java/MusicPlatform/domain/album/controller/AlbumController.java
+++ b/src/main/java/MusicPlatform/domain/album/controller/AlbumController.java
@@ -12,6 +12,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,8 +33,9 @@ public class AlbumController {
 
     @Operation(summary = "앨범 업로드")
     @PostMapping("/album")
-    public ResponseEntity<Void> uploadAlbum(@RequestBody @Valid AlbumRequestDto requestDto) {
-        albumService.save(requestDto);
+    public ResponseEntity<Void> uploadAlbum(@RequestBody @Valid AlbumRequestDto requestDto,
+                                            @CookieValue(value = "profile", defaultValue = "") String profileUuid) {
+        albumService.save(requestDto, profileUuid);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/MusicPlatform/domain/album/entity/Album.java
+++ b/src/main/java/MusicPlatform/domain/album/entity/Album.java
@@ -37,7 +37,7 @@ public class Album extends UuidEntity {
     private LocalDate releaseDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "Profile_ID", nullable = true) //todo: false로 교체한다.
+    @JoinColumn(name = "PROFILE_ID", nullable = false)
     private Profile profile;
 
     @Column(nullable = false)

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -10,6 +10,8 @@ import MusicPlatform.domain.album.service.dto.response.AlbumGetResponseDto;
 import MusicPlatform.domain.album.service.dto.response.AlbumResponseDto;
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
+import MusicPlatform.domain.profile.entity.Profile;
+import MusicPlatform.domain.profile.service.ProfileService;
 import MusicPlatform.domain.profile.service.dto.response.ProfileResponseDto;
 import MusicPlatform.domain.track.entity.Track;
 import MusicPlatform.domain.track.repository.dto.response.TrackResponseDto;
@@ -32,6 +34,7 @@ public class AlbumService {
     private final AlbumRepository albumRepository;
     private final TrackService trackService;
     private final ArtistService artistService;
+    private final ProfileService profileService;
 
     @Transactional(readOnly = true)
     public Album getByUuid(String uuid) {
@@ -39,12 +42,13 @@ public class AlbumService {
                 .orElseThrow(() -> new BusinessException(NOT_FOUND_ALBUM));
     }
 
-    public void save(AlbumRequestDto requestDto) {
+    public void save(AlbumRequestDto requestDto, String profileUuid) {
+        Profile profile = profileService.getByUuid(profileUuid);
         Album album = Album.builder()
                 .artImage(requestDto.albumArt())
                 .title(requestDto.title())
                 .description(requestDto.description())
-                //.profile() //todo 현재 프로필을 가져온다.
+                .profile(profile)
                 .releaseDate(LocalDate.now())
                 .build();
         albumRepository.save(album);

--- a/src/main/java/MusicPlatform/domain/artist/controller/ArtistController.java
+++ b/src/main/java/MusicPlatform/domain/artist/controller/ArtistController.java
@@ -3,6 +3,7 @@ package MusicPlatform.domain.artist.controller;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/artist")
+@Tag(name = "회원 (Artist)")
 public class ArtistController {
 
     private final ArtistService artistService;

--- a/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
@@ -27,6 +27,10 @@ public class CookieService {
         return this.makeCookie("access_token", null, 0);
     }
 
+    public Cookie makeProfileCookie(String profileUuid) {
+        return this.makeCookie("profile", profileUuid, maxAge);
+    }
+
     private Cookie makeCookie(String key, String value, int maxAge) {
         Cookie cookie = new Cookie(key, value);
         cookie.setSecure(true); // HTTPS에서만 쿠키가 전송되도록 설정
@@ -41,7 +45,10 @@ public class CookieService {
     public void authenticate(String uuid, List<? extends GrantedAuthority> role, HttpServletResponse response) {
         String accessToken = jwtService.createToken(uuid, role);
         response.addCookie(this.makeAccessTokenCookie(accessToken));
-        
         log.info("쿠키 저장 = " + accessToken);
+    }
+
+    public void saveProfileCookie(String uuid, HttpServletResponse response) {
+        response.addCookie(this.makeProfileCookie(uuid));
     }
 }

--- a/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
+++ b/src/main/java/MusicPlatform/domain/oauth2/service/CookieService.java
@@ -45,10 +45,11 @@ public class CookieService {
     public void authenticate(String uuid, List<? extends GrantedAuthority> role, HttpServletResponse response) {
         String accessToken = jwtService.createToken(uuid, role);
         response.addCookie(this.makeAccessTokenCookie(accessToken));
-        log.info("쿠키 저장 = " + accessToken);
+        log.info("access token 쿠키 저장 = " + accessToken);
     }
 
     public void saveProfileCookie(String uuid, HttpServletResponse response) {
         response.addCookie(this.makeProfileCookie(uuid));
+        log.info("profile 쿠키 저장 = " + uuid);
     }
 }

--- a/src/main/java/MusicPlatform/domain/profile/controller/ProfileController.java
+++ b/src/main/java/MusicPlatform/domain/profile/controller/ProfileController.java
@@ -1,0 +1,42 @@
+package MusicPlatform.domain.profile.controller;
+
+import MusicPlatform.domain.profile.service.ProfileService;
+import MusicPlatform.domain.profile.service.dto.response.ProfileResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/profile")
+@Tag(name = "프로필 (Profile)")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @PreAuthorize("hasAnyAuthority('ROLE_USER')")
+    @Operation(summary = "현재 선택된 프로필 조회")
+    @GetMapping
+    public ResponseEntity<ProfileResponseDto> getMyProfile(
+            @CookieValue(value = "profile", defaultValue = "") String profileInfo, HttpServletResponse response) {
+        ProfileResponseDto responseDto = profileService.get(profileInfo, response);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PreAuthorize("hasAnyAuthority('ROLE_USER')")
+    @Operation(summary = "현재 선택된 프로필 변경")
+    @PostMapping("/{uuid}")
+    public ResponseEntity<ProfileResponseDto> changeProfile(@PathVariable String uuid, HttpServletResponse response) {
+        ProfileResponseDto responseDto = profileService.change(uuid, response);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/MusicPlatform/domain/profile/controller/ProfileController.java
+++ b/src/main/java/MusicPlatform/domain/profile/controller/ProfileController.java
@@ -27,8 +27,8 @@ public class ProfileController {
     @Operation(summary = "현재 선택된 프로필 조회")
     @GetMapping
     public ResponseEntity<ProfileResponseDto> getMyProfile(
-            @CookieValue(value = "profile", defaultValue = "") String profileInfo, HttpServletResponse response) {
-        ProfileResponseDto responseDto = profileService.get(profileInfo, response);
+            @CookieValue(value = "profile", defaultValue = "") String profileUuid, HttpServletResponse response) {
+        ProfileResponseDto responseDto = profileService.get(profileUuid, response);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/MusicPlatform/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/MusicPlatform/domain/profile/repository/ProfileRepository.java
@@ -3,10 +3,14 @@ package MusicPlatform.domain.profile.repository;
 import MusicPlatform.domain.profile.entity.Profile;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     Optional<Profile> findByUuid(String uuid);
 
+    @Query("SELECT p from Profile p "
+            + "WHERE p.artist.uuid = :artistUuid "
+            + "AND p.isMain = true ")
     Profile findByArtistUuidAndMainIsTrue(String artistUuid);
 }

--- a/src/main/java/MusicPlatform/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/MusicPlatform/domain/profile/repository/ProfileRepository.java
@@ -1,8 +1,12 @@
 package MusicPlatform.domain.profile.repository;
 
 import MusicPlatform.domain.profile.entity.Profile;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
+    Optional<Profile> findByUuid(String uuid);
+
+    Profile findByArtistUuidAndMainIsTrue(String artistUuid);
 }

--- a/src/main/java/MusicPlatform/domain/profile/service/ProfileService.java
+++ b/src/main/java/MusicPlatform/domain/profile/service/ProfileService.java
@@ -1,8 +1,15 @@
 package MusicPlatform.domain.profile.service;
 
+import static MusicPlatform.global.error.BusinessError.NOT_FOUND_PROFILE;
+
 import MusicPlatform.domain.artist.entity.Artist;
+import MusicPlatform.domain.oauth2.service.CookieService;
 import MusicPlatform.domain.profile.entity.Profile;
 import MusicPlatform.domain.profile.repository.ProfileRepository;
+import MusicPlatform.domain.profile.service.dto.response.ProfileResponseDto;
+import MusicPlatform.global.error.BusinessException;
+import MusicPlatform.global.helper.AuthorizationHelper;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +20,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProfileService {
 
     private final ProfileRepository profileRepository;
+    private final AuthorizationHelper authorizationHelper;
+    private final CookieService cookieService;
+
+    @Transactional(readOnly = true)
+    public Profile getByUuid(String uuid) {
+        return profileRepository.findByUuid(uuid).orElseThrow(
+                () -> new BusinessException(NOT_FOUND_PROFILE)
+        );
+    }
 
     public void createProfile(Artist artist) {
         Profile profile = Profile.builder()
@@ -22,5 +38,30 @@ public class ProfileService {
                 .isMain(true)
                 .build();
         profileRepository.save(profile);
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileResponseDto get(String uuid, HttpServletResponse response) {
+        try {
+            Profile profile = uuid.isBlank() ? changeToMain(response) : getByUuid(uuid);
+            return ProfileResponseDto.from(profile);
+        } catch (BusinessException e) {
+            Profile profile = changeToMain(response);
+            return ProfileResponseDto.from(profile);
+        }
+    }
+
+    private Profile changeToMain(HttpServletResponse response) {
+        String artistUuid = authorizationHelper.getMyUuid();
+        Profile mainProfile = profileRepository.findByArtistUuidAndMainIsTrue(artistUuid);
+        cookieService.saveProfileCookie(mainProfile.getUuid(), response);
+        return mainProfile;
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileResponseDto change(String uuid, HttpServletResponse response) {
+        Profile profile = getByUuid(uuid);
+        cookieService.saveProfileCookie(uuid, response);
+        return ProfileResponseDto.from(profile);
     }
 }

--- a/src/main/java/MusicPlatform/domain/profile/service/ProfileService.java
+++ b/src/main/java/MusicPlatform/domain/profile/service/ProfileService.java
@@ -11,9 +11,11 @@ import MusicPlatform.global.error.BusinessException;
 import MusicPlatform.global.helper.AuthorizationHelper;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -52,6 +54,7 @@ public class ProfileService {
     }
 
     private Profile changeToMain(HttpServletResponse response) {
+        log.info("profile 쿠키 존재하지 않음.");
         String artistUuid = authorizationHelper.getMyUuid();
         Profile mainProfile = profileRepository.findByArtistUuidAndMainIsTrue(artistUuid);
         cookieService.saveProfileCookie(mainProfile.getUuid(), response);

--- a/src/main/java/MusicPlatform/domain/track/entity/Track.java
+++ b/src/main/java/MusicPlatform/domain/track/entity/Track.java
@@ -40,20 +40,15 @@ public class Track extends UuidEntity {
     @JoinColumn(name = "ALBUM_ID", nullable = false)
     private Album album;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    // @JoinColumn(name = "Profile_ID", nullable = false) // todo: 인가 구현 이후 주석 해제
-    private Profile profile;
-
     @Column(nullable = false)
     private boolean isDeleted;
 
     @Builder
-    private Track(String title, String lyric, String song_url, Album album, Profile profile) {
+    private Track(String title, String lyric, String song_url, Album album) {
         this.title = title;
         this.lyric = lyric;
         this.song_url = song_url;
         this.album = album;
-        this.profile = profile;
     }
 
     public String getAlbumArt() {
@@ -61,7 +56,7 @@ public class Track extends UuidEntity {
     }
 
     public Artist getArtist() {
-        return this.profile.getArtist();
+        return this.album.getProfile().getArtist();
     }
 
     public void update(String title, String lyric) {

--- a/src/main/java/MusicPlatform/domain/track/entity/Track.java
+++ b/src/main/java/MusicPlatform/domain/track/entity/Track.java
@@ -59,6 +59,10 @@ public class Track extends UuidEntity {
         return this.album.getProfile().getArtist();
     }
 
+    public Profile getProfile() {
+        return this.album.getProfile();
+    }
+
     public void update(String title, String lyric) {
         this.title = title;
         this.lyric = lyric;

--- a/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
@@ -13,7 +13,7 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
     Optional<Track> findByUuid(String uuid);
 
     @Query("SELECT t FROM Track t "
-            + "JOIN t.profile p "
+            + "JOIN t.album.profile p "
             + "JOIN p.artist a "
             + "WHERE a = :artist")
     List<Track> findAllByArtist(Artist artist);

--- a/src/main/java/MusicPlatform/domain/track/service/TrackService.java
+++ b/src/main/java/MusicPlatform/domain/track/service/TrackService.java
@@ -36,11 +36,9 @@ public class TrackService {
     }
 
     public void save(TrackRequestDto requestDto, Album album) {
-        // String songUrl = s3Service.uploadToS3(); //todo:  s3 파일 업로드 구현
         Track track = Track.builder()
                 .title(requestDto.title())
                 .lyric(requestDto.lyric())
-                .profile(null) //todo: 인가 구현
                 .album(album)
                 .song_url("temp url")
                 .build();

--- a/src/main/java/MusicPlatform/global/error/BusinessError.java
+++ b/src/main/java/MusicPlatform/global/error/BusinessError.java
@@ -16,6 +16,9 @@ public enum BusinessError {
     //Track
     NOT_FOUND_TRACK(HttpStatus.NOT_FOUND, "트랙을 찾을 수 없습니다."),
 
+    //Profile
+    NOT_FOUND_PROFILE(HttpStatus.NOT_FOUND, "프로필을 찾을 수 없습니다."),
+
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #16 

## 📝 작업 내용
<img width="919" alt="image" src="https://github.com/user-attachments/assets/fc98f7a2-9a0b-4f9c-a4cd-28e590194afb">

원래 access_token에서 profile 정보를 함께 관리하려고 했는데 따로 Cookie로 관리하는 걸로 수정했습니다!
#16 이슈 내에 이유를 짧게 작성해두었는데 확인해주시고 따로 cookie로 관리하는게 나을지 아니면 access_token에서 함께 관리하는게 나을지 이야기 나누어보고 싶습니다

현재 구현은 아래와 같습니다.
- 프로필 조회
  - 쿠키가 존재하지 않거나 변조되었을 경우 -> artist의 main profile 조회 및 cookie 등록
  - 쿠키가 존재할 경우 -> 해당 uuid의 profile 조회
- 프로필 변경
  - 쿠키의 변경도 리소스 변경에 해당한다고 하여 Get요청이 아닌 Post요청을 사용하였습니다. 
  - 클라이언트가 제공한 profile의 uuid로 쿠키 변경
  - 클라이언트가 제공한 uuid가 존재하지 않는경우 Exception throw

