### PR TITLE
Feature/#64 특정 아티스트의 플레이리스트 목록 조회 api를 구현한다

### DIFF
--- a/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
+++ b/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AlbumRepository extends JpaRepository<Album, Long> {
     Optional<Album> findByUuid(String uuid);
-    List<Album> getAllByArtist(Artist artist);
+    List<Album> findAllByArtist(Artist artist);
 }

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -74,7 +74,7 @@ public class AlbumService {
     @Transactional(readOnly = true)
     public List<AlbumResponseDto> getAllByArtist(String uuid) {
         Artist artist = artistService.findByUuid(uuid);
-        List<Album> albums = albumRepository.getAllByArtist(artist);
+        List<Album> albums = albumRepository.findAllByArtist(artist);
 
         return albums.stream()
                 .map(AlbumResponseDto::from)

--- a/src/main/java/MusicPlatform/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/MusicPlatform/domain/playlist/controller/PlaylistController.java
@@ -77,6 +77,13 @@ public class PlaylistController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(summary = "특정 아티스트의 플레이리스트 목록 조회")
+    @GetMapping("/artists/{uuid}/playlists")
+    public ResponseEntity<List<PlaylistResponseDto>> getAllByArtist(@PathVariable String uuid) {
+        List<PlaylistResponseDto> responseDto = playlistService.getAllByArtist(uuid);
+        return ResponseEntity.ok(responseDto);
+    }
+
     //삭제
     @PreAuthorize("hasAnyAuthority('ROLE_USER')")
     @Operation(summary = "플레이리스트 삭제")

--- a/src/main/java/MusicPlatform/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/MusicPlatform/domain/playlist/repository/PlaylistRepository.java
@@ -1,10 +1,13 @@
 package MusicPlatform.domain.playlist.repository;
 
+import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.playlist.entity.Playlist;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
 
     Optional<Playlist> findByUuid(String uuid);
+    List<Playlist> findAllByArtist(Artist artist);
 }

--- a/src/main/java/MusicPlatform/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/MusicPlatform/domain/playlist/service/PlaylistService.java
@@ -95,6 +95,19 @@ public class PlaylistService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<PlaylistResponseDto> getAllByArtist(String uuid) {
+        Artist artist = artistService.findByUuid(uuid);
+        List<Playlist> playlists = playlistRepository.findAllByArtist(artist);
+
+        return playlists.stream()
+                .map(playlist -> {
+                    List<PlaylistItemResponseDto> playlistItemResponseDtos = playlistItemService.convertToDto(playlist);
+                    return PlaylistResponseDto.from(playlist, playlistItemResponseDtos);
+                })
+                .toList();
+    }
+
     public void deletePlaylist(String artistUuid, String uuid) {
         Playlist playlist = findByUuid(uuid);
         isAuthenticated(artistUuid, playlist.getArtist().getUuid());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #64

## 📝 작업 내용

- 특정 아티스트의 플레이리스트 목록 조회 api를 구현했습니다. 
- 특정 아티스트의 앨범 목록 조회 api에서 사용하는 JPA Repository 메서드 중 잘못된 것을 수정했습니다.