### PR TITLE
Feature/#46 순환 의존을 해결한다

### DIFF
--- a/src/main/java/MusicPlatform/domain/playlist/_item/service/PlaylistItemService.java
+++ b/src/main/java/MusicPlatform/domain/playlist/_item/service/PlaylistItemService.java
@@ -7,7 +7,6 @@ import MusicPlatform.domain.playlist.entity.Playlist;
 import MusicPlatform.domain.track.entity.Track;
 import MusicPlatform.domain.track.service.TrackService;
 import java.util.List;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,7 @@ public class PlaylistItemService {
     }
 
     public void save(Playlist playlist, String trackUuid) {
-        Track track = trackService.getByUuid(trackUuid);
+        Track track = trackService.findByUuid(trackUuid);
         PlaylistItem playlistItem = PlaylistItem.builder()
                 .playlist(playlist)
                 .track(track)

--- a/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
+++ b/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
@@ -40,8 +40,8 @@ public class TrackController {
 
     @Operation(summary = "트랙 조회")
     @GetMapping("/tracks/{uuid}")
-    public ResponseEntity<TrackFullResponseDto> getByUuid(@PathVariable String uuid) {
-        TrackFullResponseDto responseDto = trackService.getTrack(uuid);
+    public ResponseEntity<TrackFullResponseDto> getTrack(@PathVariable String uuid) {
+        TrackFullResponseDto responseDto = trackService.getByUuid(uuid);
         return ResponseEntity.ok(responseDto);
     }
 
@@ -64,15 +64,15 @@ public class TrackController {
 
     @Operation(summary = "트랙 수정")
     @PatchMapping("/tracks/{uuid}")
-    public ResponseEntity<Void> updateByUuid(@RequestBody @Valid TrackUpdateRequestDto requestDto,
-                                             @PathVariable String uuid) {
+    public ResponseEntity<Void> updateTrack(@RequestBody @Valid TrackUpdateRequestDto requestDto,
+                                            @PathVariable String uuid) {
         trackService.updateByUuid(requestDto, uuid);
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "트랙 삭제")
     @DeleteMapping("/tracks/{uuid}")
-    public ResponseEntity<Void> deleteByUuid(@PathVariable String uuid) {
+    public ResponseEntity<Void> deleteTrack(@PathVariable String uuid) {
         trackService.deleteByUuid(uuid);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
+++ b/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
@@ -1,7 +1,5 @@
 package MusicPlatform.domain.track.controller;
 
-import MusicPlatform.domain.album.entity.Album;
-import MusicPlatform.domain.album.service.AlbumService;
 import MusicPlatform.domain.track.service.dto.request.TrackRequestDto;
 import MusicPlatform.domain.track.service.dto.request.TrackUpdateRequestDto;
 import MusicPlatform.domain.track.service.dto.response.TrackFullResponseDto;
@@ -31,14 +29,12 @@ import jakarta.validation.Valid;
 public class TrackController {
 
     private final TrackService trackService;
-    private final AlbumService albumService;
 
     @Operation(summary = "트랙 업로드")
     @PostMapping(value = "/albums/{uuid}/tracks")
     public ResponseEntity<Void> uploadTrack(@RequestBody @Valid TrackRequestDto requestDto,
                                             @PathVariable String uuid) {
-        Album album = albumService.getByUuid(uuid);
-        trackService.save(requestDto, album);
+        trackService.save(requestDto, uuid);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/MusicPlatform/domain/track/service/TrackService.java
+++ b/src/main/java/MusicPlatform/domain/track/service/TrackService.java
@@ -1,8 +1,10 @@
 package MusicPlatform.domain.track.service;
 
+import static MusicPlatform.global.error.BusinessError.NOT_FOUND_ALBUM;
 import static MusicPlatform.global.error.BusinessError.NOT_FOUND_TRACK;
 
 import MusicPlatform.domain.album.entity.Album;
+import MusicPlatform.domain.album.repository.AlbumRepository;
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.track.entity.Track;
@@ -25,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TrackService {
     private final TrackRepository trackRepository;
+    private final AlbumRepository albumRepository;
     private final ArtistService artistService;
 
     @Transactional(readOnly = true)
@@ -33,13 +36,14 @@ public class TrackService {
                 new BusinessException(NOT_FOUND_TRACK));
     }
 
-
     @Transactional(readOnly = true)
     public Page<Track> getAllByAlbum(Album album, Pageable pageable) {
         return trackRepository.findAllByAlbum(album, pageable);
     }
 
-    public void save(TrackRequestDto requestDto, Album album) {
+    public void save(TrackRequestDto requestDto, String albumUuid) {
+        Album album = albumRepository.findByUuid(albumUuid)
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_ALBUM));
         Track track = Track.builder()
                 .title(requestDto.title())
                 .lyric(requestDto.lyric())

--- a/src/main/java/MusicPlatform/domain/track/service/TrackService.java
+++ b/src/main/java/MusicPlatform/domain/track/service/TrackService.java
@@ -31,7 +31,7 @@ public class TrackService {
     private final ArtistService artistService;
 
     @Transactional(readOnly = true)
-    public Track getByUuid(String uuid) {
+    public Track findByUuid(String uuid) {
         return trackRepository.findByUuid(uuid).orElseThrow(() ->
                 new BusinessException(NOT_FOUND_TRACK));
     }
@@ -55,8 +55,8 @@ public class TrackService {
     }
 
     @Transactional(readOnly = true)
-    public TrackFullResponseDto getTrack(String uuid) {
-        Track track = getByUuid(uuid);
+    public TrackFullResponseDto getByUuid(String uuid) {
+        Track track = findByUuid(uuid);
         return TrackFullResponseDto.from(track);
     }
 
@@ -79,13 +79,13 @@ public class TrackService {
 
     public void updateByUuid(TrackUpdateRequestDto requestDto, String uuid) {
         //todo: 인가 필요
-        Track track = getByUuid(uuid);
+        Track track = findByUuid(uuid);
         track.update(requestDto.title(), requestDto.lyric());
     }
 
     public void deleteByUuid(String uuid) {
         //todo: 인가 필요
-        Track track = getByUuid(uuid);
+        Track track = findByUuid(uuid);
         trackRepository.delete(track);
         //s3에 업로드된 파일도 삭제해야하는가? (복구 불가?)
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #46

## 📝 작업 내용

(자세한 문제 내용은 #46에 나와있습니다.)
이중 3번 방식을 채택했습니다. 1번 방식을 따를 경우 계층 구조가 (현재로썬) 불필요하게 복잡해진다는 단점이 있고, 2번 방식을 따를 경우 객체간 책임의 분리가 적절하게 이루어지지 않을것 같았습니다.
따라서 2번 방식을 절충하여, 하위 관계에 속해있는 도메인에 대해서만 상위 도메인의 Repository를 참조 가능하능하도록 개발할 예정입니다.

현재 Album-Track의 관계에서 Album의 하위에 속하는 Track의 Service가 Album의 Respository를 참조 가능하게끔 수정하는 것으로 순환 의존을 해결했습니다. 

(Artist - Profile 또한 순환 의존 관계에 존재하나 Profile이 Deprecated됨에 따라 따로 수정하진 않았습니다.)

