### PR TITLE
Feature/#76 플레이리스트 추가 구현

### DIFF
--- a/src/main/java/MusicPlatform/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/MusicPlatform/domain/playlist/controller/PlaylistController.java
@@ -51,6 +51,16 @@ public class PlaylistController {
     }
 
     @PreAuthorize("hasAnyAuthority('ROLE_USER')")
+    @Operation(summary = "플레이리스트 커버 이미지 수정")
+    @PutMapping("/{uuid}/cover-image")
+    public ResponseEntity<Void> updatePlaylistCoverImage(@AuthenticationPrincipal String artistUuid,
+                                                         @PathVariable String uuid,
+                                                         String coverImageLink) {
+        playlistService.updateCoverImage(artistUuid, uuid, coverImageLink);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasAnyAuthority('ROLE_USER')")
     @Operation(summary = "플레이리스트 내 트랙 수정 및 삭제")
     @PutMapping("/{uuid}/tracks")
     public ResponseEntity<Void> updatePlaylistTrack(@AuthenticationPrincipal String artistUuid,

--- a/src/main/java/MusicPlatform/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/MusicPlatform/domain/playlist/controller/PlaylistController.java
@@ -77,7 +77,7 @@ public class PlaylistController {
             @PathVariable String uuid,
             @RequestParam(value = "itemPage", required = false, defaultValue = "0") int pageNo,
             @RequestParam(value = "itemPageSize", required = false, defaultValue = "10") int pageSize) {
-        PlaylistFullResponseDto responseDto = playlistService.getPlaylist(uuid, pageNo, pageSize);
+        PlaylistFullResponseDto responseDto = playlistService.getByUuid(uuid, pageNo, pageSize);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/MusicPlatform/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/MusicPlatform/domain/playlist/controller/PlaylistController.java
@@ -61,7 +61,7 @@ public class PlaylistController {
     }
 
     @PreAuthorize("hasAnyAuthority('ROLE_USER')")
-    @Operation(summary = "플레이리스트 내 트랙 수정 및 삭제")
+    @Operation(summary = "플레이리스트 내 트랙 추가 및 삭제")
     @PutMapping("/{uuid}/tracks")
     public ResponseEntity<Void> updatePlaylistTrack(@AuthenticationPrincipal String artistUuid,
                                                     @PathVariable String uuid,

--- a/src/main/java/MusicPlatform/domain/playlist/entity/Playlist.java
+++ b/src/main/java/MusicPlatform/domain/playlist/entity/Playlist.java
@@ -35,7 +35,7 @@ public class Playlist extends UuidEntity {
     private String coverImageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ARTIST_ID", nullable = true)
+    @JoinColumn(name = "ARTIST_ID")
     private Artist artist;
 
     @Column(nullable = false)

--- a/src/main/java/MusicPlatform/domain/playlist/entity/Playlist.java
+++ b/src/main/java/MusicPlatform/domain/playlist/entity/Playlist.java
@@ -32,6 +32,8 @@ public class Playlist extends UuidEntity {
     @Column(nullable = false)
     private String description;
 
+    private String coverImageUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ARTIST_ID", nullable = true)
     private Artist artist;
@@ -40,10 +42,15 @@ public class Playlist extends UuidEntity {
     private boolean isDeleted;
 
     @Builder
-    private Playlist(String title, String description, Artist artist) {
+    private Playlist(String title, String description, String coverImageUrl, Artist artist) {
         this.title = title;
         this.description = description;
+        this.coverImageUrl = coverImageUrl;
         this.artist = artist;
+    }
+
+    public void changeCoverImage (String coverImgUrl) {
+        this.coverImageUrl = coverImgUrl;
     }
 
     public void update(String title, String description) {

--- a/src/main/java/MusicPlatform/domain/playlist/entity/Playlist.java
+++ b/src/main/java/MusicPlatform/domain/playlist/entity/Playlist.java
@@ -49,7 +49,7 @@ public class Playlist extends UuidEntity {
         this.artist = artist;
     }
 
-    public void changeCoverImage (String coverImgUrl) {
+    public void updateCoverImage (String coverImgUrl) {
         this.coverImageUrl = coverImgUrl;
     }
 

--- a/src/main/java/MusicPlatform/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/MusicPlatform/domain/playlist/service/PlaylistService.java
@@ -83,7 +83,7 @@ public class PlaylistService {
     }
 
     @Transactional(readOnly = true)
-    public PlaylistFullResponseDto getPlaylist(String uuid, int itemPageNo, int itemPageSize) {
+    public PlaylistFullResponseDto getByUuid(String uuid, int itemPageNo, int itemPageSize) {
         Playlist playlist = findByUuid(uuid);
         Pageable itemPageable = PageRequest.of(itemPageNo, itemPageSize, Sort.by("createdAt").descending());
         List<PlaylistItemResponseDto> playlistItemResponseDtos = playlistItemService.convertToDto(playlist,

--- a/src/main/java/MusicPlatform/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/MusicPlatform/domain/playlist/service/PlaylistService.java
@@ -88,7 +88,7 @@ public class PlaylistService {
         Pageable itemPageable = PageRequest.of(itemPageNo, itemPageSize, Sort.by("createdAt").descending());
         List<PlaylistItemResponseDto> playlistItemResponseDtos = playlistItemService.convertToDto(playlist,
                 itemPageable);
-        return PlaylistFullResponseDto.from(playlist, playlistItemResponseDtos);
+        return PlaylistFullResponseDto.from(playlist, playlistItemResponseDtos, playlist.getArtist());
     }
 
     @Transactional(readOnly = true)
@@ -101,7 +101,7 @@ public class PlaylistService {
                 .map(playlist -> {
                     List<PlaylistItemResponseDto> playlistItemResponseDtos = playlistItemService.convertToDto(playlist,
                             itemPageable);
-                    return PlaylistFullResponseDto.from(playlist, playlistItemResponseDtos);
+                    return PlaylistFullResponseDto.from(playlist, playlistItemResponseDtos, playlist.getArtist());
                 })
                 .toList();
     }
@@ -116,7 +116,7 @@ public class PlaylistService {
                 .map(playlist -> {
                     List<PlaylistItemResponseDto> playlistItemResponseDtos = playlistItemService.convertToDto(playlist,
                             itemPageable);
-                    return PlaylistFullResponseDto.from(playlist, playlistItemResponseDtos);
+                    return PlaylistFullResponseDto.from(playlist, playlistItemResponseDtos, playlist.getArtist());
                 })
                 .toList();
     }

--- a/src/main/java/MusicPlatform/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/MusicPlatform/domain/playlist/service/PlaylistService.java
@@ -60,6 +60,13 @@ public class PlaylistService {
         playlist.update(requestDto.title(), requestDto.description());
     }
 
+    public void updateCoverImage(String artistUuid, String uuid, String coverImageLink) {
+        Playlist playlist = findByUuid(uuid);
+        isAuthenticated(artistUuid, playlist.getArtist().getUuid());
+        playlist.updateCoverImage(coverImageLink);
+    }
+
+
     public void update(String artistUuid, String uuid, PlaylistItemUpdateRequestDto requestDto) {
         Playlist playlist = findByUuid(uuid);
         isAuthenticated(artistUuid, playlist.getArtist().getUuid());

--- a/src/main/java/MusicPlatform/domain/playlist/service/dto/response/PlaylistBasicResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/playlist/service/dto/response/PlaylistBasicResponseDto.java
@@ -7,13 +7,15 @@ import lombok.Builder;
 public record PlaylistBasicResponseDto(
         String uuid,
         String title,
-        String description
+        String description,
+        String coverImageUrl
 ) {
     public static PlaylistBasicResponseDto from(Playlist playlist) {
         return PlaylistBasicResponseDto.builder()
                 .uuid(playlist.getUuid())
                 .title(playlist.getTitle())
                 .description(playlist.getDescription())
+                .coverImageUrl(playlist.getCoverImageUrl())
                 .build();
     }
 }

--- a/src/main/java/MusicPlatform/domain/playlist/service/dto/response/PlaylistFullResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/playlist/service/dto/response/PlaylistFullResponseDto.java
@@ -1,5 +1,7 @@
 package MusicPlatform.domain.playlist.service.dto.response;
 
+import MusicPlatform.domain.artist.entity.Artist;
+import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
 import MusicPlatform.domain.playlist._item.service.dto.response.PlaylistItemResponseDto;
 import MusicPlatform.domain.playlist.entity.Playlist;
 import java.util.List;
@@ -8,12 +10,14 @@ import lombok.Builder;
 @Builder
 public record PlaylistFullResponseDto(
         PlaylistBasicResponseDto playlistBasicResponseDto,
-        List<PlaylistItemResponseDto> playlistItemResponseDtos
+        List<PlaylistItemResponseDto> playlistItemResponseDtos,
+        ArtistResponseDto artistResponseDto
 ) {
-    public static PlaylistFullResponseDto from(Playlist playlist, List<PlaylistItemResponseDto> playlistItemResponseDtos) {
+    public static PlaylistFullResponseDto from(Playlist playlist, List<PlaylistItemResponseDto> playlistItemResponseDtos, Artist artist) {
         return PlaylistFullResponseDto.builder()
                 .playlistBasicResponseDto(PlaylistBasicResponseDto.from(playlist))
                 .playlistItemResponseDtos(playlistItemResponseDtos)
+                .artistResponseDto(ArtistResponseDto.from(artist))
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #76

## 📝 작업 내용

플레이리스트 관련하여 추가 구현해야하는 내용을 개발했습니다. 

1. 플레이리스트 조회시 생성자가 조회되지 않던 문제 해결
  - 제가 DTO로 아티스트 정보를 안넘겨줘서 이번에 수정했습니다 ^^;;
2. 플레이리스트에 커버 필드 추가
3. ~~트랙 포함되지 않은 플레이리스트 생성 가능하도록 수정~~
  - 제가 해봤는데 생성 가능해서 프론트 개발자분에게 문의해둔 상태입니다. 
4. ~~플레이리스트에 트랙 추가 api 개발~~
  - '플레이리스트 내 트랙 수정 및 삭제'라는 이름으로 존재하는 api입니다
  - 설명이 모호한거 같아서 '플레이리스트 내 트랙 추가 및 삭제'로 이름 변경했습니다....

### 기타
- 플레이리스트와 다대일 관계에 있는 Artist 필드를 임시로 nullable 처리해뒀었는데, 이번에 개발하며 삭제했습니다.
- 메서드명 통일을 위해 Service 계층의 플레이리스트 조회 api 명을 `getByUuid`로 수정했습니다.
