### PR TITLE
fix: 회원 조회시 Description, Link를 함께 조회하도록 수정한다.

### DIFF
--- a/src/main/java/MusicPlatform/domain/artist/service/dto/response/ArtistResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/dto/response/ArtistResponseDto.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 public record ArtistResponseDto(
         String uuid,
         String name,
+        String description,
+        String link1,
+        String link2,
         Role role,
         String email,
         String artistImage
@@ -16,6 +19,9 @@ public record ArtistResponseDto(
         return ArtistResponseDto.builder()
                 .uuid(artist.getUuid())
                 .name(artist.getName())
+                .description(artist.getDescription())
+                .link1(artist.getLink1())
+                .link2(artist.getLink2())
                 .role(artist.getRole())
                 .email(artist.getEmail())
                 .artistImage(artist.getArtistImage())


### PR DESCRIPTION
#84

## #️⃣ 연관된 이슈

close: #84

## 📝 작업 내용

Artist 필드에 추가된 Description과 Link 속성이 조회 Dto에 포함되지 않아 조회해오지 못하는 문제가 있었습니다. 
이를 조회 Dto에 추가하여 해결했습니다. 

