### PR TITLE
Feature/#86 track 조회시 track file url을 추가한다

### DIFF
--- a/src/main/java/MusicPlatform/domain/track/entity/Track.java
+++ b/src/main/java/MusicPlatform/domain/track/entity/Track.java
@@ -33,7 +33,7 @@ public class Track extends UuidEntity {
     private String lyric;
 
     @Column(nullable = false)
-    private String song_url;
+    private String trackUrl;
 
     @Column(nullable = false)
     private int duration;
@@ -46,10 +46,10 @@ public class Track extends UuidEntity {
     private boolean isDeleted;
 
     @Builder
-    private Track(String title, String lyric, String song_url, int duration, Album album) {
+    private Track(String title, String lyric, String trackUrl, int duration, Album album) {
         this.title = title;
         this.lyric = lyric;
-        this.song_url = song_url;
+        this.trackUrl = trackUrl;
         this.duration = duration;
         this.album = album;
     }

--- a/src/main/java/MusicPlatform/domain/track/service/TrackService.java
+++ b/src/main/java/MusicPlatform/domain/track/service/TrackService.java
@@ -49,7 +49,7 @@ public class TrackService {
                 .lyric(requestDto.lyric())
                 .duration(requestDto.duration())
                 .album(album)
-                .song_url(requestDto.trackFile())
+                .trackUrl(requestDto.trackFile())
                 .build();
         trackRepository.save(track);
     }

--- a/src/main/java/MusicPlatform/domain/track/service/dto/response/TrackBasicResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/track/service/dto/response/TrackBasicResponseDto.java
@@ -8,6 +8,7 @@ public record TrackBasicResponseDto(
         String uuid,
         String title,
         String lyric,
+        String trackUrl,
         int duration,
         String artUrl
 ) {
@@ -15,6 +16,7 @@ public record TrackBasicResponseDto(
         return TrackBasicResponseDto.builder()
                 .uuid(track.getUuid())
                 .title(track.getTitle())
+                .trackUrl(track.getTrackUrl())
                 .lyric(track.getLyric())
                 .duration(track.getDuration())
                 .artUrl(track.getAlbumArt())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #86

## 📝 작업 내용

- Java 네이밍 컨벤션에 맞지 않는 객체 필드명을 수정했습니다.
  - song_url -> trackUrl
- Track 조회 dto에 trackUrl 필드를 추가했습니다. 
