### PR TITLE
refactor: 자식 객체가 부모 객체의 Service를 참조하도록 변경

### DIFF
--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -12,8 +12,8 @@ import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
 import MusicPlatform.domain.track.entity.Track;
+import MusicPlatform.domain.track.repository.TrackRepository;
 import MusicPlatform.domain.track.service.dto.response.TrackBasicResponseDto;
-import MusicPlatform.domain.track.service.TrackService;
 import MusicPlatform.global.error.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AlbumService {
     private final AlbumRepository albumRepository;
-    private final TrackService trackService;
+    private final TrackRepository trackRepository;
     private final ArtistService artistService;
 
     @Transactional(readOnly = true)
@@ -91,7 +91,7 @@ public class AlbumService {
     }
 
     private AlbumFullResponseDto convertToDto(Album album, Pageable trackPageable) {
-        Page<Track> tracks = trackService.getAllByAlbum(album, trackPageable);
+        Page<Track> tracks = trackRepository.findAllByAlbum(album, trackPageable);
         return AlbumFullResponseDto.builder()
                 .albumResponseDto(AlbumBasicResponseDto.from(album))
                 .trackResponseDtos(tracks.stream()

--- a/src/main/java/MusicPlatform/domain/track/service/TrackService.java
+++ b/src/main/java/MusicPlatform/domain/track/service/TrackService.java
@@ -1,10 +1,9 @@
 package MusicPlatform.domain.track.service;
 
-import static MusicPlatform.global.error.BusinessError.NOT_FOUND_ALBUM;
 import static MusicPlatform.global.error.BusinessError.NOT_FOUND_TRACK;
 
 import MusicPlatform.domain.album.entity.Album;
-import MusicPlatform.domain.album.repository.AlbumRepository;
+import MusicPlatform.domain.album.service.AlbumService;
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.track.entity.Track;
@@ -27,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TrackService {
     private final TrackRepository trackRepository;
-    private final AlbumRepository albumRepository;
+    private final AlbumService albumService;
     private final ArtistService artistService;
 
     @Transactional(readOnly = true)
@@ -36,14 +35,8 @@ public class TrackService {
                 new BusinessException(NOT_FOUND_TRACK));
     }
 
-    @Transactional(readOnly = true)
-    public Page<Track> getAllByAlbum(Album album, Pageable pageable) {
-        return trackRepository.findAllByAlbum(album, pageable);
-    }
-
     public void save(TrackRequestDto requestDto, String albumUuid) {
-        Album album = albumRepository.findByUuid(albumUuid)
-                .orElseThrow(() -> new BusinessException(NOT_FOUND_ALBUM));
+        Album album = albumService.getByUuid(albumUuid);
         Track track = Track.builder()
                 .title(requestDto.title())
                 .lyric(requestDto.lyric())


### PR DESCRIPTION
#46

## #️⃣ 연관된 이슈

close: #46 

## 📝 작업 내용

부모 객체 -> 자식 객체의 Service 참조, 자식 객체 -> 부모 객체의 Repository 참조에서
자식 객체 -> 부모 객체의 Service 참조, 부모 객체 -> 자식 객체의 Repository 참조로 변경했습니다.