### PR TITLE
Feature/#88 완전 종속되는 요소에 대한 양방향 전환

### DIFF
--- a/src/main/java/MusicPlatform/domain/album/_comment/entity/AlbumComment.java
+++ b/src/main/java/MusicPlatform/domain/album/_comment/entity/AlbumComment.java
@@ -35,7 +35,7 @@ public class AlbumComment extends UuidEntity {
     @JoinColumn(name = "ARTIST_ID", nullable = false)
     private Artist artist;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ALBUM_ID", nullable = false)
     private Album album;
 

--- a/src/main/java/MusicPlatform/domain/album/_comment/entity/AlbumComment.java
+++ b/src/main/java/MusicPlatform/domain/album/_comment/entity/AlbumComment.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -35,7 +34,7 @@ public class AlbumComment extends UuidEntity {
     @JoinColumn(name = "ARTIST_ID", nullable = false)
     private Artist artist;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ALBUM_ID", nullable = false)
     private Album album;
 

--- a/src/main/java/MusicPlatform/domain/album/_comment/entity/AlbumComment.java
+++ b/src/main/java/MusicPlatform/domain/album/_comment/entity/AlbumComment.java
@@ -35,7 +35,7 @@ public class AlbumComment extends UuidEntity {
     @JoinColumn(name = "ARTIST_ID", nullable = false)
     private Artist artist;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ALBUM_ID", nullable = false)
     private Album album;
 

--- a/src/main/java/MusicPlatform/domain/album/_like/entity/AlbumLike.java
+++ b/src/main/java/MusicPlatform/domain/album/_like/entity/AlbumLike.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,7 +26,7 @@ public class AlbumLike extends UuidEntity {
     @JoinColumn(name = "ARTIST_ID", nullable = false)
     private Artist artist;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ALBUM_ID", nullable = false)
     private Album album;
 }

--- a/src/main/java/MusicPlatform/domain/album/_like/entity/AlbumLike.java
+++ b/src/main/java/MusicPlatform/domain/album/_like/entity/AlbumLike.java
@@ -27,7 +27,7 @@ public class AlbumLike extends UuidEntity {
     @JoinColumn(name = "ARTIST_ID", nullable = false)
     private Artist artist;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ALBUM_ID", nullable = false)
     private Album album;
 }

--- a/src/main/java/MusicPlatform/domain/album/_like/entity/AlbumLike.java
+++ b/src/main/java/MusicPlatform/domain/album/_like/entity/AlbumLike.java
@@ -27,7 +27,7 @@ public class AlbumLike extends UuidEntity {
     @JoinColumn(name = "ARTIST_ID", nullable = false)
     private Artist artist;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ALBUM_ID", nullable = false)
     private Album album;
 }

--- a/src/main/java/MusicPlatform/domain/album/entity/Album.java
+++ b/src/main/java/MusicPlatform/domain/album/entity/Album.java
@@ -3,6 +3,7 @@ package MusicPlatform.domain.album.entity;
 import MusicPlatform.domain.album._comment.entity.AlbumComment;
 import MusicPlatform.domain.album._like.entity.AlbumLike;
 import MusicPlatform.domain.artist.entity.Artist;
+import MusicPlatform.domain.track.entity.Track;
 import MusicPlatform.global.entity.UuidEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -45,6 +46,9 @@ public class Album extends UuidEntity {
 
     @OneToMany(mappedBy = "album", orphanRemoval = true)
     private List<AlbumLike> albumLikes;
+    
+    @OneToMany(mappedBy = "album", orphanRemoval = true)
+    private List<Track> tracks;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ARTIST_ID", nullable = false)

--- a/src/main/java/MusicPlatform/domain/album/entity/Album.java
+++ b/src/main/java/MusicPlatform/domain/album/entity/Album.java
@@ -1,5 +1,7 @@
 package MusicPlatform.domain.album.entity;
 
+import MusicPlatform.domain.album._comment.entity.AlbumComment;
+import MusicPlatform.domain.album._like.entity.AlbumLike;
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.global.entity.UuidEntity;
 import jakarta.persistence.Column;
@@ -7,8 +9,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,6 +39,12 @@ public class Album extends UuidEntity {
 
     @Column(nullable = false)
     private LocalDate releaseDate;
+
+    @OneToMany(mappedBy = "album", orphanRemoval = true)
+    private List<AlbumComment> albumComments;
+
+    @OneToMany(mappedBy = "album", orphanRemoval = true)
+    private List<AlbumLike> albumLikes;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ARTIST_ID", nullable = false)

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -87,6 +87,7 @@ public class AlbumService {
     public void deleteByUuid(String uuid) {
         //todo: 내가 업로드한 앨범인지 확인한다.
         Album album = getByUuid(uuid);
+        trackRepository.deleteAllByAlbum(album);
         albumRepository.delete(album);
     }
 

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -12,13 +12,13 @@ import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
 import MusicPlatform.domain.track.entity.Track;
-import MusicPlatform.domain.track.repository.TrackRepository;
 import MusicPlatform.domain.track.service.dto.response.TrackBasicResponseDto;
 import MusicPlatform.global.error.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -30,7 +30,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AlbumService {
     private final AlbumRepository albumRepository;
-    private final TrackRepository trackRepository;
     private final ArtistService artistService;
 
     @Transactional(readOnly = true)
@@ -87,12 +86,11 @@ public class AlbumService {
     public void deleteByUuid(String uuid) {
         //todo: 내가 업로드한 앨범인지 확인한다.
         Album album = getByUuid(uuid);
-        trackRepository.deleteAllByAlbum(album);
         albumRepository.delete(album);
     }
 
     private AlbumFullResponseDto convertToDto(Album album, Pageable trackPageable) {
-        Page<Track> tracks = trackRepository.findAllByAlbum(album, trackPageable);
+        Page<Track> tracks = new PageImpl<>(album.getTracks(), trackPageable, album.getTracks().size());
         return AlbumFullResponseDto.builder()
                 .albumResponseDto(AlbumBasicResponseDto.from(album))
                 .trackResponseDtos(tracks.stream()

--- a/src/main/java/MusicPlatform/domain/artist/entity/Artist.java
+++ b/src/main/java/MusicPlatform/domain/artist/entity/Artist.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+// todo: 회원 탈퇴시 회원을 삭제하지 않고 이름을 '존재하지 않는 사용자'로 변경한다.
+
 @Entity
 @Getter
 @Table(name = "artist")

--- a/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
@@ -89,6 +89,7 @@ public class ArtistService {
     }
 
     public void removeArtist() {
+        //todo: 회원 탈퇴시 리소스는 어떻게 처리할 것인가?
         String uuid = authorizationHelper.getMyUuid();
         Artist artist = findByUuid(uuid);
         artistRepository.delete(artist);

--- a/src/main/java/MusicPlatform/domain/playlist/entity/Playlist.java
+++ b/src/main/java/MusicPlatform/domain/playlist/entity/Playlist.java
@@ -1,13 +1,16 @@
 package MusicPlatform.domain.playlist.entity;
 import MusicPlatform.domain.artist.entity.Artist;
 
+import MusicPlatform.domain.playlist._item.entity.PlaylistItem;
 import MusicPlatform.global.entity.UuidEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,6 +40,9 @@ public class Playlist extends UuidEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ARTIST_ID")
     private Artist artist;
+
+    @OneToMany(mappedBy = "playlist", orphanRemoval = true)
+    private List<PlaylistItem> playlistItems;
 
     @Column(nullable = false)
     private boolean isDeleted;

--- a/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
@@ -20,5 +20,4 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
     List<Track> findAllByArtist(Artist artist);
 
     Page<Track> findAllByAlbum(Album album, Pageable pageable);
-    void deleteAllByAlbum(Album album);
 }

--- a/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
@@ -20,4 +20,5 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
     List<Track> findAllByArtist(Artist artist);
 
     Page<Track> findAllByAlbum(Album album, Pageable pageable);
+    void deleteAllByAlbum(Album album);
 }

--- a/src/test/java/MusicPlatform/controller/s3/S3ControllerTest.java
+++ b/src/test/java/MusicPlatform/controller/s3/S3ControllerTest.java
@@ -1,4 +1,4 @@
-package MusicPlatform.s3.service;
+package MusicPlatform.controller.s3;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/MusicPlatform/helper/cleanData.java
+++ b/src/test/java/MusicPlatform/helper/cleanData.java
@@ -9,6 +9,6 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Sql(value = "/clean.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = "/sql/clean.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 public @interface cleanData {
 }

--- a/src/test/java/MusicPlatform/service/album/AlbumServiceTest.java
+++ b/src/test/java/MusicPlatform/service/album/AlbumServiceTest.java
@@ -1,0 +1,43 @@
+package MusicPlatform.service.album;
+
+import static org.hibernate.validator.internal.util.Contracts.assertTrue;
+
+import MusicPlatform.domain.album.entity.Album;
+import MusicPlatform.domain.album.repository.AlbumRepository;
+import MusicPlatform.domain.album.service.AlbumService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest
+@Transactional
+@Sql("/sql/service-test-data.sql")
+public class AlbumServiceTest {
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private AlbumService albumService;
+    @Autowired
+    private AlbumRepository albumRepository;
+
+    @Test
+    @DisplayName("Album 삭제 시 그 하위 종속 요소가 함께 삭제된다.")
+    public void Album_삭제_시_그_하위_종속_요소가_함께_삭제된다() throws Exception {
+        //given
+        Album album = albumRepository.findById(1L).orElseThrow();
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM track t where t.album_id = ? and t.is_deleted = false", Integer.class, album.getId());
+        assertTrue(count > 0, "data.sql 정상 실행되지 않음");
+
+        //when
+        albumService.deleteByUuid(album.getUuid());
+        albumRepository.flush();
+
+        //then
+        count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM track t where t.album_id = ? and t.is_deleted = false", Integer.class, album.getId());
+        assertTrue(count == 0,"하위 종속 요소 Track 삭제되지 않음");
+    }
+}

--- a/src/test/java/MusicPlatform/service/playlist/PlaylistServiceTest.java
+++ b/src/test/java/MusicPlatform/service/playlist/PlaylistServiceTest.java
@@ -1,0 +1,40 @@
+package MusicPlatform.service.playlist;
+
+import static org.hibernate.validator.internal.util.Contracts.assertTrue;
+
+import MusicPlatform.domain.playlist.entity.Playlist;
+import MusicPlatform.domain.playlist.repository.PlaylistRepository;
+import MusicPlatform.domain.playlist.service.PlaylistService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+@Transactional
+@SpringBootTest
+@Sql("/sql/service-test-data.sql")
+public class PlaylistServiceTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    PlaylistService playlistService;
+    @Autowired
+    PlaylistRepository playlistRepository;
+
+    @Test
+    @DisplayName("Playlist 삭제 시 그 하위 종속 요소가 함께 삭제된다.")
+    public void Playlist_삭제시_하위_종속_항목이_삭제된다() throws Exception {
+        //given
+        Playlist playlist = playlistRepository.findById(1L).orElseThrow();
+        //when
+        playlistService.deletePlaylist(playlist.getArtist().getUuid(), playlist.getUuid());
+        playlistRepository.flush();
+        //then
+        int count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM playlist_item pi WHERE pi.playlist_id = ?",Integer.class, playlist.getId());
+        assertTrue(count == 0 , "하위 종속 요소 PlaylistItem 삭제되지 않음");
+    }
+}

--- a/src/test/resources/sql/clean.sql
+++ b/src/test/resources/sql/clean.sql
@@ -1,14 +1,14 @@
 delete
-from album;
-
-delete
 from album_like;
 
 delete
 from album_comment;
 
 delete
-from profile;
+from track;
+
+delete
+from album;
 
 delete
 from artist;
@@ -18,6 +18,3 @@ from playlist_item;
 
 delete
 from playlist;
-
-delete
-from track;

--- a/src/test/resources/sql/service-test-data.sql
+++ b/src/test/resources/sql/service-test-data.sql
@@ -1,10 +1,14 @@
 insert into artist (id, uuid, name, email, link1, link2, description, provider, artist_image, role, is_deleted)
 values (1, UUID(), 'artist1', 'aaaa@gmail.com', 'https://instagram.com', NULL, 'hello I am artist1', 'google', 'image.jpg', 'ROLE_USER', false);
-insert into album (`id`, `uuid`, `title`, `description`, `art_image`, `release_date`, `artist_id`, `is_deleted`)
+insert into album (id, uuid, title, description, art_image, release_date, artist_id, is_deleted)
 values (1, UUID(), 'album1', 'This is a description of the album', 'image.jpg', '2025-01-01', 1, false);
-insert into album_like (`id`, `uuid`, `artist_id`, `album_id`)
+insert into album_like (id, uuid, artist_id, album_id)
 values (1, UUID(), 1, 1);
-insert into album_comment (`id`, `uuid`, `comment`, `artist_id`, `album_id`, `is_deleted`)
+insert into album_comment (id, uuid, comment, artist_id, album_id, is_deleted)
 values (1, UUID(), 'awesome song!', 1, 1, false);
-insert into track (`id`, `uuid`, `title`, `lyric`, `track_url`, `duration`, `album_id`, `is_deleted`)
+insert into track (id, uuid, title, lyric, track_url, duration, album_id, is_deleted)
 values (1, UUID(), 'title', 'lyric', 's3.com', 360, 1, false);
+insert into playlist (id, uuid, title, description, cover_image_url, artist_id, is_deleted)
+values (1, UUID(), 'title', 'cool playlist', 'image.jpg', 1, false);
+insert into playlist_item (id, uuid, track_id, playlist_id)
+values (1, UUID(), 1,1);

--- a/src/test/resources/sql/service-test-data.sql
+++ b/src/test/resources/sql/service-test-data.sql
@@ -1,0 +1,10 @@
+insert into artist (id, uuid, name, email, link1, link2, description, provider, artist_image, role, is_deleted)
+values (1, UUID(), 'artist1', 'aaaa@gmail.com', 'https://instagram.com', NULL, 'hello I am artist1', 'google', 'image.jpg', 'ROLE_USER', false);
+insert into album (`id`, `uuid`, `title`, `description`, `art_image`, `release_date`, `artist_id`, `is_deleted`)
+values (1, UUID(), 'album1', 'This is a description of the album', 'image.jpg', '2025-01-01', 1, false);
+insert into album_like (`id`, `uuid`, `artist_id`, `album_id`)
+values (1, UUID(), 1, 1);
+insert into album_comment (`id`, `uuid`, `comment`, `artist_id`, `album_id`, `is_deleted`)
+values (1, UUID(), 'awesome song!', 1, 1, false);
+insert into track (`id`, `uuid`, `title`, `lyric`, `track_url`, `duration`, `album_id`, `is_deleted`)
+values (1, UUID(), 'title', 'lyric', 's3.com', 360, 1, false);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #88

## 📝 작업 내용

이슈에 자세한 내용 설명되어있습니다.
- 완전 종속되는 요소 (Album-Track, Playlist-PlaylistItem)을 양방향 다대일로 전환하였습니다.
- 위 요소에 대해 OrphanRemoval을 적용하였습니다. 
- OrphanRemoval을 확인하는 테스트 코드를 작성했습니다.

### 추가 작업이 필요한 부분
현재 완전 종속되는 요소의 경우 함께 삭제하는 것으로 처리했지만, 그렇지 않은 경우 (Track-PlaylistItem) 삭제 로직을 어떻게 처리할지 고민해야 합니다.
또한 Artist-Album, Artist-Playlist또한 완전 종속 상태이나, 양방향 다대일로 전환하지 않고 다른 삭제 로직을 추가하도록 합니다.
- Track-PlaylistItem: 삭제된 Track을 지니는 PlaylistItem 조회시, PlaylistItem을 함께 삭제하는 것이 아니라  '조회할수 없는 트랙입니다', '비공개되었거나 삭제된 트랙입니다'와 같이 메세지가 표시되도록 한다.
- Artist-Album, Artist-Playlist: 회원 탈퇴시 Artist명을 '탈퇴한 회원'으로 변경하고 Album과 Playlist를 유지한다.
