### PR TITLE
Feature/#91 track 삭제시 playlist를 조회하지 못하는 오류

### DIFF
--- a/src/main/java/MusicPlatform/domain/playlist/_item/service/dto/response/PlaylistItemResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/playlist/_item/service/dto/response/PlaylistItemResponseDto.java
@@ -7,11 +7,14 @@ import lombok.Builder;
 @Builder
 public record PlaylistItemResponseDto(
         String uuid,
-       TrackFullResponseDto trackGetResponseDto
+        Boolean isDisabled,
+        TrackFullResponseDto trackGetResponseDto
 ) {
     public static PlaylistItemResponseDto from(PlaylistItem playlistItem) {
+        // Track의 상태가 변경됨에 따라 연관된 모든 Playlist를 업데이트하기 보다는 Playlist 조회 시 필터링하도록 한다.
         return PlaylistItemResponseDto.builder()
                 .uuid(playlistItem.getUuid())
+                .isDisabled(playlistItem.getTrack().isDeleted())
                 .trackGetResponseDto(TrackFullResponseDto.from(playlistItem.getTrack()))
                 .build();
     }

--- a/src/main/java/MusicPlatform/domain/track/entity/Track.java
+++ b/src/main/java/MusicPlatform/domain/track/entity/Track.java
@@ -20,7 +20,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @Getter
 @Table(name = "track")
-@SQLRestriction("is_deleted = false")
+//@SQLRestriction("is_deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE track SET is_deleted = true where id = ?")
 public class Track extends UuidEntity {

--- a/src/test/java/MusicPlatform/service/playlist/PlaylistServiceTest.java
+++ b/src/test/java/MusicPlatform/service/playlist/PlaylistServiceTest.java
@@ -2,10 +2,17 @@ package MusicPlatform.service.playlist;
 
 import static org.hibernate.validator.internal.util.Contracts.assertTrue;
 
+import MusicPlatform.domain.playlist._item.service.PlaylistItemService;
+import MusicPlatform.domain.playlist._item.service.dto.response.PlaylistItemResponseDto;
 import MusicPlatform.domain.playlist.entity.Playlist;
 import MusicPlatform.domain.playlist.repository.PlaylistRepository;
 import MusicPlatform.domain.playlist.service.PlaylistService;
+import MusicPlatform.domain.track.entity.Track;
+import MusicPlatform.domain.track.repository.TrackRepository;
+import MusicPlatform.domain.track.service.TrackService;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,13 +24,21 @@ import org.springframework.test.context.jdbc.Sql;
 @SpringBootTest
 @Sql("/sql/service-test-data.sql")
 public class PlaylistServiceTest {
-
+    @Autowired
+    private EntityManager entityManager;
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
     @Autowired
     PlaylistService playlistService;
     @Autowired
+    PlaylistItemService playlistItemService;
+    @Autowired
+    TrackService trackService;
+    @Autowired
     PlaylistRepository playlistRepository;
+    @Autowired
+    TrackRepository trackRepository;
 
     @Test
     @DisplayName("Playlist 삭제 시 그 하위 종속 요소가 함께 삭제된다.")
@@ -34,7 +49,30 @@ public class PlaylistServiceTest {
         playlistService.deletePlaylist(playlist.getArtist().getUuid(), playlist.getUuid());
         playlistRepository.flush();
         //then
-        int count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM playlist_item pi WHERE pi.playlist_id = ?",Integer.class, playlist.getId());
-        assertTrue(count == 0 , "하위 종속 요소 PlaylistItem 삭제되지 않음");
+        int count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM playlist_item pi WHERE pi.playlist_id = ?",
+                Integer.class, playlist.getId());
+        assertTrue(count == 0, "하위 종속 요소 PlaylistItem 삭제되지 않음");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Track 삭제시 해당 Track과 연관된 PlaylistItem의 상태를 disabled로 조회한다")
+    public void Track_삭제시_해당_Track과_연관된_PlaylistItem의_상태를_disabled로_조회한다() throws Exception {
+        //given
+        Track track = trackRepository.findById(1L).orElseThrow();
+        //when
+        trackService.deleteByUuid(track.getUuid());
+        System.out.println(track.isDeleted()); //false
+        entityManager.flush();
+
+        Playlist playlist = playlistRepository.findById(1L).orElseThrow();
+        System.out.println(playlist.getPlaylistItems().get(0).getTrack().isDeleted()); // true
+
+        //then
+        List<PlaylistItemResponseDto> responseDtos = playlistItemService.convertToDto(playlist, null);
+        boolean isDisabled = responseDtos.stream().filter(PlaylistItemResponseDto::isDisabled)
+                .map(dto -> dto.trackGetResponseDto().trackResponseDto().uuid()).toList().contains(track.getUuid());
+
+        assertTrue(isDisabled, "PlaylistItemDto의 필드가 disabled=true되지 않음");
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #91

## 📝 작업 내용

Track 삭제시 Playlist를 조회하는 오류를 해결했습니다.

- 오류 원인
  PlaylistItem은 Track을 참조하고 있음 -> Track이 삭제되자 삭제된 Track을 조회할 수 없어 오류 발생

- 해결
  Track의 @SQLRestriction 삭제 -> isDeleted가 true인 값도 조회 가능하도록 함
  PlaylistItemResponseDto에 isDisabled 필드 추가, 만일 Track의 isDeleted가 true인 경우 true를 
 반환하도록 함
 성능을 위해 Track 삭제시 연관된 PlaylistItem을 모두 Write하기 보다는 PlaylistItem 조회 시 필터링 가능하도록 했음

추가로 관련 테스트 코드를 작성했습니다.
