### PR TITLE
fix: Album의 Track 조회시 페이지네이션이 적용되지 않는 문제 해결

### DIFF
--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -12,13 +12,13 @@ import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
 import MusicPlatform.domain.track.entity.Track;
+import MusicPlatform.domain.track.repository.TrackRepository;
 import MusicPlatform.domain.track.service.dto.response.TrackBasicResponseDto;
 import MusicPlatform.global.error.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AlbumService {
     private final AlbumRepository albumRepository;
+    private final TrackRepository trackRepository;
     private final ArtistService artistService;
 
     @Transactional(readOnly = true)
@@ -90,7 +91,7 @@ public class AlbumService {
     }
 
     private AlbumFullResponseDto convertToDto(Album album, Pageable trackPageable) {
-        Page<Track> tracks = new PageImpl<>(album.getTracks(), trackPageable, album.getTracks().size());
+        Page<Track> tracks = trackRepository.findAllByAlbum(album, trackPageable);
         return AlbumFullResponseDto.builder()
                 .albumResponseDto(AlbumBasicResponseDto.from(album))
                 .trackResponseDtos(tracks.stream()


### PR DESCRIPTION
#92

## #️⃣ 연관된 이슈

close: #92 
#90 

## 📝 작업 내용

이번에 연관 관계를 수정하면서 Page 반환값을 Track 레포에서 받아오는 것이 아니라 Album의 참조값을 그대로 반환하는 방식으로 수정한 것이 문제가 되었습니다.
직접 DB를 pageable로 조회하지 않으면 pageable이 적용되지 않습니다!!

- Album에 속하는 Track 조회시 Album의 Track 필드를 참조하는 것이 아닌, Repository를 조회하는 것으로 변경