### PR TITLE
feature/#95-특정 아티스트의 트랙 조회 구현

### DIFF
--- a/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
+++ b/src/main/java/MusicPlatform/domain/track/controller/TrackController.java
@@ -49,16 +49,22 @@ public class TrackController {
     @GetMapping("/tracks")
     public ResponseEntity<List<TrackFullResponseDto>> getAll(
             @RequestParam(value = "page", required = false, defaultValue = "0") int pageNo,
-            @RequestParam(value = "pageSize", required = false, defaultValue = "10") int pageSize) {
-        List<TrackFullResponseDto> responseDto = trackService.getAll(pageNo, pageSize);
+            @RequestParam(value = "pageSize", required = false, defaultValue = "10") int pageSize,
+            @RequestParam(value = "sortBy", required = false, defaultValue = "createdAt") String sortBy,
+            @RequestParam(value = "direction", required = false, defaultValue = "desc") String direction) {
+        List<TrackFullResponseDto> responseDto = trackService.getAll(pageNo, pageSize, sortBy, direction);
         return ResponseEntity.ok(responseDto);
     }
 
-    @Deprecated
     @Operation(summary = "특정 아티스트의 트랙 목록 조회")
     @GetMapping("/artists/{uuid}/tracks")
-    public ResponseEntity<List<TrackFullResponseDto>> getAllByArtist(@PathVariable String uuid) {
-        List<TrackFullResponseDto> responseDto = trackService.getAllByArtist(uuid);
+    public ResponseEntity<List<TrackFullResponseDto>> getAllByArtist(
+            @RequestParam(value = "page", required = false, defaultValue = "0") int pageNo,
+            @RequestParam(value = "pageSize", required = false, defaultValue = "10") int pageSize,
+            @RequestParam(value = "sortBy", required = false, defaultValue = "createdAt") String sortBy,
+            @RequestParam(value = "direction", required = false, defaultValue = "desc") String direction,
+            @PathVariable String uuid) {
+        List<TrackFullResponseDto> responseDto = trackService.getAllByArtist(uuid, pageNo, pageSize, sortBy, direction);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
@@ -17,7 +17,7 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
     @Query("SELECT t FROM Track t "
             + "JOIN t.album.artist a "
             + "WHERE a = :artist")
-    List<Track> findAllByArtist(Artist artist);
+    Page<Track> findAllByArtist(Artist artist, Pageable pageable);
 
     Page<Track> findAllByAlbum(Album album, Pageable pageable);
 }

--- a/src/main/java/MusicPlatform/domain/track/service/TrackService.java
+++ b/src/main/java/MusicPlatform/domain/track/service/TrackService.java
@@ -54,17 +54,17 @@ public class TrackService {
     }
 
     @Transactional(readOnly = true)
-    public List<TrackFullResponseDto> getAll(int pageNo, int pageSize) {
-        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
+    public List<TrackFullResponseDto> getAll(int pageNo, int pageSize, String sortBy, String direction) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
         Page<Track> tracks = trackRepository.findAll(pageable);
         return tracks.getContent().stream().map(TrackFullResponseDto::from).toList();
     }
 
-    @Deprecated // 앨범의 getAllByArtist로 대체한다.
     @Transactional(readOnly = true)
-    public List<TrackFullResponseDto> getAllByArtist(String artistUuid) {
+    public List<TrackFullResponseDto> getAllByArtist(String artistUuid, int pageNo, int pageSize, String sortBy, String direction) {
         Artist artist = artistService.findByUuid(artistUuid);
-        List<Track> tracks = trackRepository.findAllByArtist(artist);
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+        Page<Track> tracks = trackRepository.findAllByArtist(artist, pageable);
         return tracks.stream()
                 .map(TrackFullResponseDto::from)
                 .toList();


### PR DESCRIPTION
#95

## #️⃣ 연관된 이슈

close: #95

## 📝 작업 내용

- 기존에 있던 '특정 아티스트의 트랙 목록 조회 구현'을 deprecated 취소 했습니다. 
  - '특정 아티스트의 앨범 목록 조회' api를 '특정 아티스트의 트랙 목록 조회'와 동일한 기능으로 사용하려 했으나, 정렬 문제로 따로 구현하게 되었습니다.
- 특정 아티스트의 트랙 목록 조회시 pageable을 적용했습니다.
- 트랙 목록 조회 api에 sort By와 direction을 추가했습니다. 