### PR TITLE
Fix/#99 팔로워 팔로잉 로직과 관련된 오타를 수정한다

### DIFF
--- a/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
@@ -73,7 +73,7 @@ public class ArtistService {
 
     //artist를 팔로하고 있는 모든(최근 20명) 회원을 구한다.
     @Transactional(readOnly = true)
-    public List<ArtistResponseDto> findAllFollowing(String uuid) {
+    public List<ArtistResponseDto> findAllFollower(String uuid) {
         Artist artist = findByUuid(uuid);
         Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
         Page<Artist> artists = artistRepository.findAllByFollowingIsArtist(artist, pageable);
@@ -82,7 +82,7 @@ public class ArtistService {
 
     //artist가 팔로하고 있는 모든(최근 20명) 회원을 구한다.
     @Transactional(readOnly = true)
-    public List<ArtistResponseDto> findAllFollower(String uuid) {
+    public List<ArtistResponseDto> findAllFollowing(String uuid) {
         Artist artist = findByUuid(uuid);
         Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
         Page<Artist> artists = artistRepository.findAllByFollowerIsArtist(artist, pageable);

--- a/src/main/java/MusicPlatform/domain/artist/service/dto/response/ArtistResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/dto/response/ArtistResponseDto.java
@@ -24,7 +24,7 @@ public record ArtistResponseDto(
                 .description(artist.getDescription())
                 .link1(artist.getLink1())
                 .link2(artist.getLink2())
-                .follower(artist.getFollowings().size())
+                .follower(artist.getFollowers().size())
                 .following(artist.getFollowings().size())
                 .role(artist.getRole())
                 .email(artist.getEmail())

--- a/src/test/java/MusicPlatform/service/artist/ArtistServiceTest.java
+++ b/src/test/java/MusicPlatform/service/artist/ArtistServiceTest.java
@@ -28,7 +28,7 @@ public class ArtistServiceTest {
         //given
         Artist artist = artistRepository.findById(1L).orElseThrow();
         //when
-        List<ArtistResponseDto> responseDtos = artistService.findAllFollowing(artist.getUuid());
+        List<ArtistResponseDto> responseDtos = artistService.findAllFollower(artist.getUuid());
         //then
         assertThat(responseDtos.size()).isEqualTo(1);
     }
@@ -39,7 +39,7 @@ public class ArtistServiceTest {
         //given
         Artist artist = artistRepository.findById(1L).orElseThrow();
         //when
-        List<ArtistResponseDto> responseDtos = artistService.findAllFollower(artist.getUuid());
+        List<ArtistResponseDto> responseDtos = artistService.findAllFollowing(artist.getUuid());
         //then
         assertThat(responseDtos.size()).isEqualTo(2);
     }

--- a/src/test/resources/sql/follow-test-data.sql
+++ b/src/test/resources/sql/follow-test-data.sql
@@ -11,5 +11,5 @@ values (2, 1, 3);
 insert into follow (id, follower_id, following_id)
 values (3, 2, 1);
 
--- 1 follows 2, 3
--- 2 follows 1
+-- 1 follows 2, 3 (1's following number:2)
+-- 2 follows 1 (1's follower number:1)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #99

## 📝 작업 내용

이전 PR에서 작업한 내용에 오타가 있었습니다!!!

1. findAllFollower() -> 팔로잉을 조회함 / findAllFollowing() -> 팔로워를 조회함과 같은 식으로 두 메서드 역할이 바뀌어 있어 메서드명을 수정했습니다. 
2. 객체를 DTO로 변환하는 정적팩터리메서드에서 팔로워 반환값이 팔로잉으로 되어있어 이를 수정해주었습니다. 

