### PR TITLE
Feature/#99 팔로워 팔로잉 로직과 관련된 오타룰 수정한다

### DIFF
--- a/src/main/java/MusicPlatform/domain/artist/entity/Artist.java
+++ b/src/main/java/MusicPlatform/domain/artist/entity/Artist.java
@@ -49,9 +49,10 @@ public class Artist extends UuidEntity {
     @Column(nullable = false)
     private Role role;
 
-    @OneToMany(mappedBy = "follower", orphanRemoval = true)
-    private Set<Follow> followers;
+    //mappedBy 주의
     @OneToMany(mappedBy = "following", orphanRemoval = true)
+    private Set<Follow> followers;
+    @OneToMany(mappedBy = "follower", orphanRemoval = true)
     private Set<Follow> followings;
 
     @Column(nullable = false)

--- a/src/test/java/MusicPlatform/service/artist/ArtistServiceTest.java
+++ b/src/test/java/MusicPlatform/service/artist/ArtistServiceTest.java
@@ -43,4 +43,14 @@ public class ArtistServiceTest {
         //then
         assertThat(responseDtos.size()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("아티스트의 팔로잉,팔로워 수를 적절히 반환할 수 있다.")
+    public void 아티스트의_팔로잉팔로워_수를_적절히_반환할_수_있다() throws Exception {
+      //given & when
+        Artist artist = artistRepository.findById(1L).orElseThrow();
+      //then
+      assertThat(artist.getFollowers().size()).isEqualTo(1);
+      assertThat(artist.getFollowings().size()).isEqualTo(2);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #99

## 📝 작업 내용

mappedBy문제로 팔로잉 수와 팔로워 수가 바뀌어 표현되는 문제가 있었습니다. 

```java
    //수정 전
    @OneToMany(mappedBy = "follower", orphanRemoval = true)
    private Set<Follow> followers;
    @OneToMany(mappedBy = "following", orphanRemoval = true)
    private Set<Follow> followings;
``` 

followers의 mappedBy를 following으로, followings의 mappedBy를 following으로 수정하고, 관련된 테스트를 추가했습니다. 