### PR TITLE
Refactor/#102 Album, Artist 조회시 발생하는 추가 쿼리 제거

### DIFF
--- a/src/main/java/MusicPlatform/domain/album/controller/AlbumController.java
+++ b/src/main/java/MusicPlatform/domain/album/controller/AlbumController.java
@@ -50,11 +50,8 @@ public class AlbumController {
 
     @Operation(summary = "엘범 조회")
     @GetMapping("/albums/{uuid}")
-    public ResponseEntity<AlbumFullResponseDto> getByUuid(
-            @PathVariable String uuid,
-            @RequestParam(value = "trackPage", required = false, defaultValue = "0") int pageNo,
-            @RequestParam(value = "trackPageSize", required = false, defaultValue = "10") int pageSize) {
-        AlbumFullResponseDto responseDto = albumService.getAlbum(uuid, pageNo, pageSize);
+    public ResponseEntity<AlbumFullResponseDto> getByUuid(@PathVariable String uuid) {
+        AlbumFullResponseDto responseDto = albumService.getAlbum(uuid);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/MusicPlatform/domain/album/entity/Album.java
+++ b/src/main/java/MusicPlatform/domain/album/entity/Album.java
@@ -18,6 +18,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -41,12 +42,15 @@ public class Album extends UuidEntity {
     @Column(nullable = false)
     private LocalDate releaseDate;
 
+    @BatchSize(size = 20)
     @OneToMany(mappedBy = "album", orphanRemoval = true)
     private List<AlbumComment> albumComments;
 
+    @BatchSize(size = 30)
     @OneToMany(mappedBy = "album", orphanRemoval = true)
     private List<AlbumLike> albumLikes;
-    
+
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "album", orphanRemoval = true)
     private List<Track> tracks;
 

--- a/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
+++ b/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
@@ -1,9 +1,7 @@
 package MusicPlatform.domain.album.repository;
 
 import MusicPlatform.domain.album.entity.Album;
-import MusicPlatform.domain.artist.entity.Artist;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,5 +14,5 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     Slice<Album> findAllBy(Pageable pageable);
 
     Optional<Album> findByUuid(String uuid);
-    Slice<Album> findAllByArtist(Artist artist, Pageable pageable);
+    Slice<Album> findAllByArtistUuid(String uuid, Pageable pageable);
 }

--- a/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
+++ b/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
@@ -5,6 +5,7 @@ import MusicPlatform.domain.artist.entity.Artist;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,8 +13,8 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
 
     @Query("SELECT a FROM Album a "
             + "JOIN FETCH a.artist at ")
-    Page<Album> findAll(Pageable pageable);
+    Slice<Album> findAllBy(Pageable pageable);
 
     Optional<Album> findByUuid(String uuid);
-    Page<Album> findAllByArtist(Artist artist, Pageable pageable);
+    Slice<Album> findAllByArtist(Artist artist, Pageable pageable);
 }

--- a/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
+++ b/src/main/java/MusicPlatform/domain/album/repository/AlbumRepository.java
@@ -2,13 +2,18 @@ package MusicPlatform.domain.album.repository;
 
 import MusicPlatform.domain.album.entity.Album;
 import MusicPlatform.domain.artist.entity.Artist;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AlbumRepository extends JpaRepository<Album, Long> {
+
+    @Query("SELECT a FROM Album a "
+            + "JOIN FETCH a.artist at ")
+    Page<Album> findAll(Pageable pageable);
+
     Optional<Album> findByUuid(String uuid);
     Page<Album> findAllByArtist(Artist artist, Pageable pageable);
 }

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -11,15 +11,14 @@ import MusicPlatform.domain.album.service.dto.response.AlbumBasicResponseDto;
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
-import MusicPlatform.domain.track.repository.TrackRepository;
 import MusicPlatform.domain.track.service.dto.response.TrackBasicResponseDto;
 import MusicPlatform.global.error.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,14 +51,13 @@ public class AlbumService {
     @Transactional(readOnly = true)
     public AlbumFullResponseDto getAlbum(String uuid, int pageNo, int pageSize) {
         Album album = getByUuid(uuid);
-        Pageable trackPageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
         return convertToDto(album);
     }
 
     @Transactional(readOnly = true)
     public List<AlbumFullResponseDto> getAll(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
-        Page<Album> albums = albumRepository.findAll(pageable);
+        Slice<Album> albums = albumRepository.findAllBy(pageable);
         return albums.stream().map(this::convertToDto).toList();
     }
 
@@ -67,7 +65,7 @@ public class AlbumService {
     public List<AlbumBasicResponseDto> getAllByArtist(String uuid, int pageNo, int pageSize) {
         Artist artist = artistService.findByUuid(uuid);
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
-        Page<Album> albums = albumRepository.findAllByArtist(artist, pageable);
+        Slice<Album> albums = albumRepository.findAllByArtist(artist, pageable);
         return albums.stream()
                 .map(AlbumBasicResponseDto::from)
                 .toList();

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -11,7 +11,6 @@ import MusicPlatform.domain.album.service.dto.response.AlbumBasicResponseDto;
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
-import MusicPlatform.domain.track.entity.Track;
 import MusicPlatform.domain.track.repository.TrackRepository;
 import MusicPlatform.domain.track.service.dto.response.TrackBasicResponseDto;
 import MusicPlatform.global.error.BusinessException;
@@ -30,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AlbumService {
     private final AlbumRepository albumRepository;
-    private final TrackRepository trackRepository;
     private final ArtistService artistService;
 
     @Transactional(readOnly = true)
@@ -55,23 +53,21 @@ public class AlbumService {
     public AlbumFullResponseDto getAlbum(String uuid, int pageNo, int pageSize) {
         Album album = getByUuid(uuid);
         Pageable trackPageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
-        return convertToDto(album, trackPageable);
+        return convertToDto(album);
     }
 
     @Transactional(readOnly = true)
     public List<AlbumFullResponseDto> getAll(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
         Page<Album> albums = albumRepository.findAll(pageable);
-        Pageable trackPageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
-        return albums.stream().map(album -> convertToDto(album, trackPageable)).toList();
+        return albums.stream().map(this::convertToDto).toList();
     }
 
     @Transactional(readOnly = true)
     public List<AlbumBasicResponseDto> getAllByArtist(String uuid, int pageNo, int pageSize) {
-        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
         Artist artist = artistService.findByUuid(uuid);
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
         Page<Album> albums = albumRepository.findAllByArtist(artist, pageable);
-
         return albums.stream()
                 .map(AlbumBasicResponseDto::from)
                 .toList();
@@ -90,11 +86,10 @@ public class AlbumService {
         albumRepository.delete(album);
     }
 
-    private AlbumFullResponseDto convertToDto(Album album, Pageable trackPageable) {
-        Page<Track> tracks = trackRepository.findAllByAlbum(album, trackPageable);
+    private AlbumFullResponseDto convertToDto(Album album) {
         return AlbumFullResponseDto.builder()
                 .albumResponseDto(AlbumBasicResponseDto.from(album))
-                .trackResponseDtos(tracks.stream()
+                .trackResponseDtos(album.getTracks().stream()
                         .map(TrackBasicResponseDto::from)
                         .toList())
                 .artistResponseDto(ArtistResponseDto.from(album.getArtist()))

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -49,7 +49,7 @@ public class AlbumService {
     }
 
     @Transactional(readOnly = true)
-    public AlbumFullResponseDto getAlbum(String uuid, int pageNo, int pageSize) {
+    public AlbumFullResponseDto getAlbum(String uuid) {
         Album album = getByUuid(uuid);
         return convertToDto(album);
     }

--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -63,9 +63,8 @@ public class AlbumService {
 
     @Transactional(readOnly = true)
     public List<AlbumBasicResponseDto> getAllByArtist(String uuid, int pageNo, int pageSize) {
-        Artist artist = artistService.findByUuid(uuid);
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
-        Slice<Album> albums = albumRepository.findAllByArtist(artist, pageable);
+        Slice<Album> albums = albumRepository.findAllByArtistUuid(uuid, pageable);
         return albums.stream()
                 .map(AlbumBasicResponseDto::from)
                 .toList();

--- a/src/main/java/MusicPlatform/domain/artist/entity/Artist.java
+++ b/src/main/java/MusicPlatform/domain/artist/entity/Artist.java
@@ -16,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -50,8 +51,11 @@ public class Artist extends UuidEntity {
     private Role role;
 
     //mappedBy 주의
+    @BatchSize(size = 20)
     @OneToMany(mappedBy = "following", orphanRemoval = true)
     private Set<Follow> followers;
+
+    @BatchSize(size = 20)
     @OneToMany(mappedBy = "follower", orphanRemoval = true)
     private Set<Follow> followings;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #102

## 📝 작업 내용

앨범과 아티스트 조회시 발생하는 n+1 문제를 해결했습니다. 

데이터베이스에서 앨범 목록을 조회 시 모든 앨범이 다른 아티스트를 지니고 있다고 가정할 시 발생하는 쿼리는 album + n*(track + artist + follower + following)으로 총 1+n*4개의 쿼리가 발생합니다.

이번 PR에서는 이러한 추가 쿼리를 최대한 제거하는 방향으로 BatchSize와 Fetch Join을 적용하였습니다.
적용 결과 위와 동일한 상황에서 최소 album&artist + track + follower + following의 4개의 쿼리가 생성되는 것으로 개선되었습니다.

- Track, Follow에 대해 BatchSize 적용
- Album 조회시 Artist FetchJoin 적용
- Page -> Slice 변경

추가로 Album에서의 Track Pageable 적용을 삭제했습니다. (Pageable이 필요할만큼 많은 양의 Track이 담길것 같지 않기에)