### PR TITLE
Revert "fix: TrackRepository에서 직접 Pageable을 사용하도록 적용"

### DIFF
--- a/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
+++ b/src/main/java/MusicPlatform/domain/album/service/AlbumService.java
@@ -11,14 +11,11 @@ import MusicPlatform.domain.album.service.dto.response.AlbumBasicResponseDto;
 import MusicPlatform.domain.artist.entity.Artist;
 import MusicPlatform.domain.artist.service.ArtistService;
 import MusicPlatform.domain.artist.service.dto.response.ArtistResponseDto;
-import MusicPlatform.domain.track.entity.Track;
-import MusicPlatform.domain.track.repository.TrackRepository;
 import MusicPlatform.domain.track.service.dto.response.TrackBasicResponseDto;
 import MusicPlatform.global.error.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -31,7 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AlbumService {
     private final AlbumRepository albumRepository;
-    private final TrackRepository trackRepository;
     private final ArtistService artistService;
 
     @Transactional(readOnly = true)
@@ -88,13 +84,9 @@ public class AlbumService {
     }
 
     private AlbumFullResponseDto convertToDto(Album album) {
-        Pageable trackPageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
-        Page<Track> tracks = trackRepository.findAllByAlbum(album, trackPageable);
-        //Pageable 적용하려면 직접 레포에서 조회해야 함 (album 직접 참고하지 말 것)
-        
         return AlbumFullResponseDto.builder()
                 .albumResponseDto(AlbumBasicResponseDto.from(album))
-                .trackResponseDtos(tracks.stream()
+                .trackResponseDtos(album.getTracks().stream()
                         .map(TrackBasicResponseDto::from)
                         .toList())
                 .artistResponseDto(ArtistResponseDto.from(album.getArtist()))


### PR DESCRIPTION
Reverts BDD-CLUB/2024-2-untitled-music-back#111

Pageable이 적용되도록 코드를 수정했으나, Album에 Pageable 할 만큼 많은 양의 Track이 담기지 않을 것 같아 revert합니다. 