### PR TITLE
Feature/#108 lambda를 통한 이미지 용량 압축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 	//aws
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.amazonaws:aws-java-sdk-lambda:1.12.700'
 
 	//jasypt
 	implementation "com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5"

--- a/src/main/java/MusicPlatform/domain/aws/controller/LambdaController.java
+++ b/src/main/java/MusicPlatform/domain/aws/controller/LambdaController.java
@@ -1,0 +1,36 @@
+package MusicPlatform.domain.aws.controller;
+
+import MusicPlatform.domain.aws.service.LambdaService;
+import MusicPlatform.domain.aws.service.dto.response.LambdaResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/uploads")
+@PreAuthorize("hasAnyAuthority('ROLE_USER')")
+@Tag(name = "이미지 업로드 (lambda)")
+public class LambdaController {
+
+    private final LambdaService lambdaService;
+
+    @Operation(summary = "S3 이미지 업로드 (용량 압축)")
+    @PostMapping(value = "/images",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<LambdaResponseDto> uploadImage(@RequestPart("file") MultipartFile file) throws IOException {
+        LambdaResponseDto responseDto = lambdaService.uploadImage(file);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+}

--- a/src/main/java/MusicPlatform/domain/aws/controller/S3Controller.java
+++ b/src/main/java/MusicPlatform/domain/aws/controller/S3Controller.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/uploads")
+@PreAuthorize("hasAnyAuthority('ROLE_USER')")
 @Tag(name = "S3 업로드 (S3)")
 public class S3Controller {
 

--- a/src/main/java/MusicPlatform/domain/aws/controller/S3Controller.java
+++ b/src/main/java/MusicPlatform/domain/aws/controller/S3Controller.java
@@ -1,7 +1,7 @@
-package MusicPlatform.domain.s3.controller;
+package MusicPlatform.domain.aws.controller;
 
-import MusicPlatform.domain.s3.service.S3ImageService;
-import MusicPlatform.domain.s3.service.S3MusicService;
+import MusicPlatform.domain.aws.service.S3ImageService;
+import MusicPlatform.domain.aws.service.S3MusicService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;

--- a/src/main/java/MusicPlatform/domain/aws/controller/S3Controller.java
+++ b/src/main/java/MusicPlatform/domain/aws/controller/S3Controller.java
@@ -23,8 +23,9 @@ public class S3Controller {
     private final S3ImageService s3ImageService;
     private final S3MusicService s3MusicService;
 
+    @Deprecated
     @Operation(summary = "S3 이미지 업로드")
-    @PostMapping("/images")
+    @PostMapping("/s3images")
     public ResponseEntity<String> uploadImage(@RequestParam("file") MultipartFile file) throws IOException {
         String url = s3ImageService.uploadFile(file);
         return ResponseEntity.status(HttpStatus.CREATED).body(url);

--- a/src/main/java/MusicPlatform/domain/aws/service/LambdaService.java
+++ b/src/main/java/MusicPlatform/domain/aws/service/LambdaService.java
@@ -1,0 +1,65 @@
+package MusicPlatform.domain.aws.service;
+
+import static MusicPlatform.global.error.ApplicationError.LAMBDA_NOT_VALID;
+
+import MusicPlatform.domain.aws.service.dto.request.LambdaRequestDto;
+import MusicPlatform.domain.aws.service.dto.response.LambdaResponseDto;
+import MusicPlatform.global.error.ApplicationException;
+import com.amazonaws.services.lambda.model.GetFunctionRequest;
+import com.amazonaws.services.lambda.model.GetFunctionResult;
+import com.amazonaws.services.lambda.model.InvokeRequest;
+import com.amazonaws.services.lambda.model.InvokeResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import com.amazonaws.services.lambda.AWSLambda;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LambdaService {
+    private static final String LAMBDA_FUNCTION_NAME = "ImageCompress2";
+
+    private final AWSLambda awsLambda;
+    private final ObjectMapper objectMapper;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public LambdaResponseDto uploadImage(MultipartFile file) throws IOException {
+        validateLambda();
+        LambdaRequestDto requestDto = new LambdaRequestDto(
+                UUID.randomUUID() + "_" + file.getOriginalFilename(),
+                Base64.getEncoder().encodeToString(file.getBytes()),
+                bucketName
+        );
+        InvokeRequest invokeRequest = new InvokeRequest()
+                .withFunctionName(LAMBDA_FUNCTION_NAME)
+                .withPayload(objectMapper.writeValueAsString(requestDto));
+
+        InvokeResult invokeResult = awsLambda.invoke(invokeRequest);
+        String lambdaResult = new String(invokeResult.getPayload().array(), StandardCharsets.UTF_8);
+
+        return objectMapper.readValue(lambdaResult, LambdaResponseDto.class);
+    }
+
+    public void validateLambda() {
+        GetFunctionRequest request = new GetFunctionRequest().withFunctionName("ImageCompress2");
+        try {
+            GetFunctionResult result = awsLambda.getFunction(request);
+            log.info("Lambda 접근: " + result.getConfiguration().getFunctionName());
+        } catch (Exception e) {
+            log.info("Lambda 접근 실패: " + e.getMessage());
+            throw new ApplicationException(LAMBDA_NOT_VALID);
+        }
+    }
+}

--- a/src/main/java/MusicPlatform/domain/aws/service/S3ImageService.java
+++ b/src/main/java/MusicPlatform/domain/aws/service/S3ImageService.java
@@ -1,4 +1,4 @@
-package MusicPlatform.domain.s3.service;
+package MusicPlatform.domain.aws.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import org.springframework.stereotype.Service;

--- a/src/main/java/MusicPlatform/domain/aws/service/S3MusicService.java
+++ b/src/main/java/MusicPlatform/domain/aws/service/S3MusicService.java
@@ -1,4 +1,4 @@
-package MusicPlatform.domain.s3.service;
+package MusicPlatform.domain.aws.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import org.springframework.stereotype.Service;

--- a/src/main/java/MusicPlatform/domain/aws/service/S3Service.java
+++ b/src/main/java/MusicPlatform/domain/aws/service/S3Service.java
@@ -1,4 +1,4 @@
-package MusicPlatform.domain.s3.service;
+package MusicPlatform.domain.aws.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;

--- a/src/main/java/MusicPlatform/domain/aws/service/dto/request/LambdaRequestDto.java
+++ b/src/main/java/MusicPlatform/domain/aws/service/dto/request/LambdaRequestDto.java
@@ -1,0 +1,14 @@
+package MusicPlatform.domain.aws.service.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record LambdaRequestDto(
+        @NotNull
+        String filename,
+        @NotBlank
+        String base64Data,
+        @NotBlank
+        String bucket
+) {
+}

--- a/src/main/java/MusicPlatform/domain/aws/service/dto/response/LambdaResponseDto.java
+++ b/src/main/java/MusicPlatform/domain/aws/service/dto/response/LambdaResponseDto.java
@@ -1,0 +1,6 @@
+package MusicPlatform.domain.aws.service.dto.response;
+
+public record LambdaResponseDto(
+        String url
+) {
+}

--- a/src/main/java/MusicPlatform/global/config/aws/AwsConfig.java
+++ b/src/main/java/MusicPlatform/global/config/aws/AwsConfig.java
@@ -1,8 +1,11 @@
 package MusicPlatform.global.config.aws;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,7 +13,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class S3Config {
+public class AwsConfig {
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
     @Value("${cloud.aws.credentials.secret-key}")
@@ -19,11 +22,24 @@ public class S3Config {
     private String region;
 
     @Bean
-    public AmazonS3 amazonS3Client() {
-        AWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+    public AmazonS3 amazonS3Client(AWSCredentialsProvider awsCredentials) {
         return AmazonS3ClientBuilder.standard()
                 .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withCredentials(awsCredentials)
                 .build();
+    }
+
+    @Bean
+    public AWSLambda awsLambda(AWSCredentialsProvider awsCredentials) {
+        return AWSLambdaClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(awsCredentials)
+                .build();
+    }
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return new AWSStaticCredentialsProvider(awsCredentials);
     }
 }

--- a/src/main/java/MusicPlatform/global/error/ApplicationError.java
+++ b/src/main/java/MusicPlatform/global/error/ApplicationError.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ApplicationError {
 
     METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
+    LAMBDA_NOT_VALID(HttpStatus.BAD_REQUEST, "접근할 수 없는 람다입니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #108

## 📝 작업 내용

Lambda를 통해 업로드하는 이미지 용량을 압축하는 기능을 구현했습니다. 
(기존에는 압축이 아닌 이미지 크기를 줄이는 방향으로 용량을 줄였지만 화질이 너무 떨어져서 + Spring 서버와 따로 연동을 해두지 않아서 압축 방식을 수정했습니다.)
![압축 전](https://github.com/user-attachments/assets/69aef8be-f849-4e05-88ff-0d1f329f2d2d)
압축 전
![압축 후](https://github.com/user-attachments/assets/50f737ac-68e1-4f63-ae8e-0e9ef8c6a315)
압축 후

png 파일의 경우 1.5 MB -> 54.9KB
jpeg 파일의 경우 404.0KB -> 208.KB
webp 파일의 경우 393.2KB -> 388.8KB
정도의 압축률을 보여줍니다. 

![압축 전](https://soundflyer.s3.ap-northeast-2.amazonaws.com/resources/original/e25f2863-ebc3-4ab2-b3c7-7214d493e36c_aespa.png)
![압축 후](https://soundflyer.s3.ap-northeast-2.amazonaws.com/resources/resize/e25f2863-ebc3-4ab2-b3c7-7214d493e36c_aespa.webp)

가장 용량 절감률이 높은 PNG 파일의 화질을 비교하면 위와 같습니다 (위: 압축 전(1.5MB), 아래: 압축 후(54.9KB))