### PR TITLE
Feature/#102 Artist 관련 불필요한 쿼리 삭제

### DIFF
--- a/src/main/java/MusicPlatform/domain/artist/controller/ArtistController.java
+++ b/src/main/java/MusicPlatform/domain/artist/controller/ArtistController.java
@@ -76,14 +76,14 @@ public class ArtistController {
     }
 
     @Operation(summary = "팔로워 조회")
-    @GetMapping("artists/{uuid}/followers")
+    @GetMapping("/{uuid}/followers")
     public ResponseEntity<List<ArtistResponseDto>> getFollower(@PathVariable String uuid) {
         List<ArtistResponseDto> responseDto = artistService.findAllFollower(uuid);
         return ResponseEntity.ok(responseDto);
     }
 
     @Operation(summary = "팔로잉 조회")
-    @GetMapping("artists/{uuid}/followings")
+    @GetMapping("/{uuid}/followings")
     public ResponseEntity<List<ArtistResponseDto>> getFollowing(@PathVariable String uuid) {
         List<ArtistResponseDto> responseDto = artistService.findAllFollowing(uuid);
         return ResponseEntity.ok(responseDto);

--- a/src/main/java/MusicPlatform/domain/artist/repository/ArtistRepository.java
+++ b/src/main/java/MusicPlatform/domain/artist/repository/ArtistRepository.java
@@ -15,12 +15,12 @@ public interface ArtistRepository extends JpaRepository<Artist, Long> {
     // Artist가 팔로하고 있는 모든 회원를 구한다.
     @Query("SELECT a FROM Artist a "
             + "Join Follow f on a = f.following "
-            + "WHERE f.follower = :artist ")
-    Page<Artist> findAllByFollowerIsArtist(Artist artist, Pageable pageable);
+            + "WHERE f.follower.uuid = :artistUuid ")
+    Page<Artist> findAllByFollowerIsArtist(String artistUuid, Pageable pageable);
 
     // Artist를 팔로하고있는 모든 회원을 구한다.
     @Query("SELECT a FROM Artist a "
             + "Join Follow f on a = f.follower "
-            + "WHERE f.following = :artist ")
-    Page<Artist> findAllByFollowingIsArtist(Artist artist, Pageable pageable);
+            + "WHERE f.following.uuid = :artistUuid ")
+    Page<Artist> findAllByFollowingIsArtist(String artistUuid, Pageable pageable);
 }

--- a/src/main/java/MusicPlatform/domain/artist/repository/ArtistRepository.java
+++ b/src/main/java/MusicPlatform/domain/artist/repository/ArtistRepository.java
@@ -2,8 +2,8 @@ package MusicPlatform.domain.artist.repository;
 
 import MusicPlatform.domain.artist.entity.Artist;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -16,11 +16,11 @@ public interface ArtistRepository extends JpaRepository<Artist, Long> {
     @Query("SELECT a FROM Artist a "
             + "Join Follow f on a = f.following "
             + "WHERE f.follower.uuid = :artistUuid ")
-    Page<Artist> findAllByFollowerIsArtist(String artistUuid, Pageable pageable);
+    Slice<Artist> findAllByFollowerIsArtist(String artistUuid, Pageable pageable);
 
     // Artist를 팔로하고있는 모든 회원을 구한다.
     @Query("SELECT a FROM Artist a "
             + "Join Follow f on a = f.follower "
             + "WHERE f.following.uuid = :artistUuid ")
-    Page<Artist> findAllByFollowingIsArtist(String artistUuid, Pageable pageable);
+    Slice<Artist> findAllByFollowingIsArtist(String artistUuid, Pageable pageable);
 }

--- a/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
@@ -13,9 +13,9 @@ import MusicPlatform.global.helper.AuthorizationHelper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,7 +67,7 @@ public class ArtistService {
 
     public List<ArtistResponseDto> getAll(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
-        Page<Artist> artist = artistRepository.findAll(pageable);
+        Slice<Artist> artist = artistRepository.findAll(pageable);
         return artist.stream().map(ArtistResponseDto::from).toList();
     }
 
@@ -75,7 +75,7 @@ public class ArtistService {
     @Transactional(readOnly = true)
     public List<ArtistResponseDto> findAllFollower(String artistUuid) {
         Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
-        Page<Artist> artists = artistRepository.findAllByFollowingIsArtist(artistUuid, pageable);
+        Slice<Artist> artists = artistRepository.findAllByFollowingIsArtist(artistUuid, pageable);
         return artists.stream().map(ArtistResponseDto::from).toList();
     }
 
@@ -83,7 +83,7 @@ public class ArtistService {
     @Transactional(readOnly = true)
     public List<ArtistResponseDto> findAllFollowing(String artistUuid) {
         Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
-        Page<Artist> artists = artistRepository.findAllByFollowerIsArtist(artistUuid, pageable);
+        Slice<Artist> artists = artistRepository.findAllByFollowerIsArtist(artistUuid, pageable);
         return artists.stream().map(ArtistResponseDto::from).toList();
     }
 

--- a/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
+++ b/src/main/java/MusicPlatform/domain/artist/service/ArtistService.java
@@ -73,24 +73,21 @@ public class ArtistService {
 
     //artist를 팔로하고 있는 모든(최근 20명) 회원을 구한다.
     @Transactional(readOnly = true)
-    public List<ArtistResponseDto> findAllFollower(String uuid) {
-        Artist artist = findByUuid(uuid);
+    public List<ArtistResponseDto> findAllFollower(String artistUuid) {
         Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
-        Page<Artist> artists = artistRepository.findAllByFollowingIsArtist(artist, pageable);
+        Page<Artist> artists = artistRepository.findAllByFollowingIsArtist(artistUuid, pageable);
         return artists.stream().map(ArtistResponseDto::from).toList();
     }
 
     //artist가 팔로하고 있는 모든(최근 20명) 회원을 구한다.
     @Transactional(readOnly = true)
-    public List<ArtistResponseDto> findAllFollowing(String uuid) {
-        Artist artist = findByUuid(uuid);
+    public List<ArtistResponseDto> findAllFollowing(String artistUuid) {
         Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
-        Page<Artist> artists = artistRepository.findAllByFollowerIsArtist(artist, pageable);
+        Page<Artist> artists = artistRepository.findAllByFollowerIsArtist(artistUuid, pageable);
         return artists.stream().map(ArtistResponseDto::from).toList();
     }
 
     public ArtistResponseDto changeArtistImage(String newImage) {
-
         String uuid = authorizationHelper.getMyUuid();
         Artist artist = findByUuid(uuid);
         artist.updateImage(newImage);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#102

## 📝 작업 내용

- n+1과 관련된 문제는 #103 에서 해결했고, 이번 PR에서는 n+1과 관련없는 불필요한 쿼리들을 삭제했습니다.
  - 불필요한 Artist 조회, Page에 의한 count 쿼리   
- 잘못 작성된 엔드포인트를 수정했습니다. (/artistsartists/{uuid}/followers -> /artists/{uuid}/followers ...)



