### PR TITLE
Feature/#121 옵티마이저 조회 순서 변경

### DIFF
--- a/src/main/java/MusicPlatform/domain/track/entity/Track.java
+++ b/src/main/java/MusicPlatform/domain/track/entity/Track.java
@@ -6,6 +6,7 @@ import MusicPlatform.global.entity.UuidEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -19,10 +20,12 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
-@Table(name = "track")
 //@SQLRestriction("is_deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE track SET is_deleted = true where id = ?")
+@Table(name = "track", indexes = {
+        @Index(name = "created_deleted_track_index", columnList = "created_at, is_deleted"),
+})
 public class Track extends UuidEntity {
 
     //todo: 앨범 내 노래 순서 설정?

--- a/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
+++ b/src/main/java/MusicPlatform/domain/track/repository/TrackRepository.java
@@ -10,19 +10,19 @@ import org.springframework.data.jpa.repository.Query;
 public interface TrackRepository extends JpaRepository<Track, Long> {
 
     @Query("SELECT t FROM Track t "
-            + "JOIN FETCH t.album a "
-            + "JOIN FETCH a.artist at "
+            + "LEFT JOIN FETCH t.album a "
+            + "LEFT JOIN FETCH a.artist at "
             + "WHERE t.uuid = :uuid")
     Optional<Track> findByUuid(String uuid);
 
     @Query("SELECT t FROM Track t "
-            + "JOIN FETCH t.album a "
-            + "JOIN FETCH a.artist at "
+            + "LEFT JOIN FETCH t.album a "
+            + "LEFT JOIN FETCH a.artist at "
             + "WHERE a.uuid = :artistUuid")
     Slice<Track> findAllByArtist(String artistUuid, Pageable pageable);
 
     @Query("SELECT t FROM Track t "
-            + "JOIN FETCH t.album a "
-            + "JOIN FETCH a.artist at ")
+            + "LEFT JOIN FETCH t.album a "
+            + "LEFT JOIN FETCH a.artist at ")
     Slice<Track> findAllBySlice(Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #121 
#104 

## 📝 작업 내용

- 옵티마이저에서 Track을 드라이빙 테이블로 사용하도록 쿼리를 튜닝했습니다.
- Track 테이블에 인덱스를 적용했습니다. (DB에는 이미 적용되어 있었는데 JPA상으로 적용되어있지 않았음)


#121 에서 설명했듯 Track의 조회 쿼리가 지나치게 느린 문제가 있었습니다. (3600ms이상 소요)

```

+----+-------------+-------+------------+--------+-------------------------------------+-----------------------------+---------+---------------------------+-------+----------+----------------------------------------------+
| id | select_type | table | partitions | type   | possible_keys                       | key                         | key_len | ref                       | rows  | filtered | Extra                                        |
+----+-------------+-------+------------+--------+-------------------------------------+-----------------------------+---------+---------------------------+-------+----------+----------------------------------------------+
|  1 | SIMPLE      | a1_0  | NULL       | ALL    | PRIMARY,FKmwc4fyyxb6tfi0qba26gcf8s1 | NULL                        | NULL    | NULL                      | 19854 |    10.00 | Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | a2_0  | NULL       | eq_ref | PRIMARY                             | PRIMARY                     | 8       | soundflyer.a1_0.artist_id |     1 |    10.00 | Using where                                  |
|  1 | SIMPLE      | t1_0  | NULL       | ref    | FKaxm9pbgk7ptorfyk3o6911q05         | FKaxm9pbgk7ptorfyk3o6911q05 | 8       | soundflyer.a1_0.id        |     1 |   100.00 | NULL                                         |
+----+-------------+-------+------------+--------+-------------------------------------+-----------------------------+---------+---------------------------+-------+----------+----------------------------------------------+
```
실행 계획 확인 결과 옵티마이져가 Track이 아닌 Album을 드라이빙 테이블로 사용하고 있음을 확인하고 쿼리 튜닝에 들어갔습니다.

고려한 튜닝 내용은 아래와 같습니다. 
- 옵티마이저 힌트 사용
- 서브쿼리 사용
- Left Join 사용

위 세 방식을 적용함으로서 Track을 드라이빙 테이블로 사용하도록 옵티마이저를 강제하거나 유도할 수 있었습니다.
최종적으로는 **Left Join을 사용**했습니다.

각 방식을 사용한 실행 분석은 아래와 같습니다.

### 개선 전
```
 -> Limit: 11 row(s)  (actual time=1890.692..1890.712 rows=11 loops=1)
    -> Sort: t1_0.created_at DESC, limit input to 11 row(s) per chunk  (actual time=1890.689..1890.699 rows=11 loops=1)
        -> Stream results  (cost=2884.45 rows=377) (actual time=9.229..1860.112 rows=30019 loops=1)
            -> Nested loop inner join  (cost=2884.45 rows=377) (actual time=7.761..1759.383 rows=30019 loops=1)
                -> Nested loop inner join  (cost=2752.54 rows=199) (actual time=4.599..1302.920 rows=20008 loops=1)
                    -> Filter: (a1_0.is_deleted = false)  (cost=2057.65 rows=1985) (actual time=4.577..298.215 rows=20008 loops=1)
                        -> Table scan on a1_0  (cost=2057.65 rows=19854) (actual time=4.572..272.997 rows=20010 loops=1)
                    -> Filter: (a2_0.is_deleted = false)  (cost=0.25 rows=0.1) (actual time=0.045..0.047 rows=1 loops=20008)
                        -> Single-row index lookup on a2_0 using PRIMARY (id=a1_0.artist_id)  (cost=0.25 rows=1) (actual time=0.043..0.044 rows=1 loops=20008)
                -> Index lookup on t1_0 using FKaxm9pbgk7ptorfyk3o6911q05 (album_id=a1_0.id)  (cost=0.48 rows=2) (actual time=0.016..0.019 rows=2 loops=20008)
```
1.89초 정도의 긴 시간을 소요합니다. 

### 옵티마이저 힌트
```
 -> Limit: 11 row(s)  (cost=8318.53 rows=11) (actual time=48.488..55.013 rows=11 loops=1)
    -> Nested loop inner join  (cost=8318.53 rows=11) (actual time=48.485..54.999 rows=11 loops=1)
        -> Nested loop inner join  (cost=7562.96 rows=110) (actual time=46.155..52.588 rows=11 loops=1)
            -> Index scan on t1_0 using created_deleted_track_index (reverse)  (cost=7.31 rows=1099) (actual time=42.676..42.691 rows=11 loops=1)
            -> Filter: (a1_0.is_deleted = false)  (cost=0.25 rows=0.1) (actual time=0.896..0.897 rows=1 loops=11)
                -> Single-row index lookup on a1_0 using PRIMARY (id=t1_0.album_id)  (cost=0.25 rows=1) (actual time=0.893..0.893 rows=1 loops=11)
        -> Filter: (a2_0.is_deleted = false)  (cost=0.25 rows=0.1) (actual time=0.215..0.216 rows=1 loops=11)
            -> Single-row index lookup on a2_0 using PRIMARY (id=a1_0.artist_id)  (cost=0.25 rows=1) (actual time=0.213..0.213 rows=1 loops=11)
```
소요 시간이 55ms으로 감소했습니다.
그러나 옵티마이저 힌트는 MySQL에서만 적용 가능하다는 점을 고려하여 다른 개선 방식을 시도했습니다.

### 서브쿼리
```
 -> Nested loop inner join  (cost=6.79 rows=0.01) (actual time=2.867..3.041 rows=11 loops=1)
    -> Nested loop inner join  (cost=6.51 rows=0.1) (actual time=2.843..2.942 rows=11 loops=1)
        -> Table scan on t1_0  (cost=3.42..3.65 rows=1) (actual time=2.825..2.842 rows=11 loops=1)
            -> Materialize  (cost=1.13..1.13 rows=1) (actual time=2.820..2.820 rows=11 loops=1)
                -> Limit: 11 row(s)  (cost=1.02 rows=1) (actual time=0.068..0.126 rows=11 loops=1)
                    -> Filter: (track.is_deleted = false)  (cost=1.02 rows=1) (actual time=0.058..0.106 rows=11 loops=1)
                        -> Index scan on track using created_deleted_track_index (reverse)  (cost=1.02 rows=11) (actual time=0.053..0.090 rows=13 loops=1)
        -> Filter: (a1_0.is_deleted = false)  (cost=0.25 rows=0.1) (actual time=0.005..0.006 rows=1 loops=11)
            -> Single-row index lookup on a1_0 using PRIMARY (id=t1_0.album_id)  (cost=0.25 rows=1) (actual time=0.003..0.003 rows=1 loops=11)
    -> Filter: (a2_0.is_deleted = false)  (cost=0.26 rows=0.1) (actual time=0.005..0.006 rows=1 loops=11)
        -> Single-row index lookup on a2_0 using PRIMARY (id=a1_0.artist_id)  (cost=0.26 rows=1) (actual time=0.003..0.003 rows=1 loops=11)
```
3ms 정도의 시간이 소요됐습니다.
그러나 해당 방식은 Limit을 사용한 서브쿼리를 사용하여 track으로부터 Drived table을 생성하는 방식으로, JPQL에서는 LIMIT을 사용하지 못한다는 점, LIMIT으로 사용할 Pageable 값은 클라이언트에서 정한다는 점을 고려하여 다른 방식을 고려하기로 했습니다.

### Left Join
```
 -> Limit: 11 row(s)  (cost=14893.73 rows=11) (actual time=0.108..0.316 rows=11 loops=1)
    -> Nested loop left join  (cost=14893.73 rows=11) (actual time=0.105..0.303 rows=11 loops=1)
        -> Nested loop left join  (cost=7446.88 rows=11) (actual time=0.091..0.195 rows=11 loops=1)
            -> Index scan on t1_0 using created_deleted_track_index (reverse)  (cost=0.03 rows=11) (actual time=0.071..0.086 rows=11 loops=1)
            -> Filter: (a1_0.is_deleted = false)  (cost=0.25 rows=1) (actual time=0.005..0.007 rows=1 loops=11)
                -> Single-row index lookup on a1_0 using PRIMARY (id=t1_0.album_id)  (cost=0.25 rows=1) (actual time=0.003..0.004 rows=1 loops=11)
        -> Filter: (a2_0.is_deleted = false)  (cost=0.25 rows=1) (actual time=0.005..0.007 rows=1 loops=11)
            -> Single-row index lookup on a2_0 using PRIMARY (id=a1_0.artist_id)  (cost=0.25 rows=1) (actual time=0.003..0.003 rows=1 loops=11)
```
0.3ms 정도의 시간이 소요되었습니다.

LEFT JOIN을 사용하여 Track을 드라이빙 테이블로 사용하도록 옵티마이저를 유도했습니다.
JPQL에서 사용하기에 적절하고, 실행 시간도 가장 짧기 때문에 위 방법을 선택했습니다. 