### PR TITLE
Feature/#128 백엔드 api 기본 경로 설정 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -93,6 +93,8 @@ jasypt:
     password: ${JASYPT_KEY}
 
 server:
+  servlet:
+    context-path: /v1
   front: https://soundsforest.com
   api: https://soundsforest.com/v1
   error-page: https://soundsforest.com/error


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#128

## 📝 작업 내용

기존에는 Nginx를 사용하여 /v1/* 경로로 들어오는 요청을 http://spring/*로 리다이렉션 하고 있었습니다.
현재 Nginx를 더이상 사용하지 않으므로 /v1/* 요청을 백엔드에서 응답하기 위해 백엔드 기본 api 접두사가 /v1이 되도록 설정을 추가했습니다.